### PR TITLE
E stop fixes and regimen persistance

### DIFF
--- a/lib/bot_command/bot_commands.ex
+++ b/lib/bot_command/bot_commands.ex
@@ -212,7 +212,12 @@ defmodule Command do
   """
   @spec read_param(number) :: command_output
   def read_param(param) when is_integer param do
-    Gcode.Handler.block_send "F21 P#{param}"
+    case Gcode.Handler.block_send "F21 P#{param}" do
+      :timeout ->
+        Process.sleep(100)
+        read_param(param)
+      whatever -> whatever
+    end
   end
 
   @doc """
@@ -220,8 +225,14 @@ defmodule Command do
   """
   @spec update_param(number | nil, number) :: command_output
   def update_param(param, value) when is_integer param do
-    Gcode.Handler.block_send "F22 P#{param} V#{value}"
-    Command.read_param(param)
+    case Gcode.Handler.block_send "F22 P#{param} V#{value}" do
+      :timeout ->
+        Process.sleep(10)
+        update_param(param, value)
+      _ ->
+      Process.sleep(100)
+      Command.read_param(param)
+    end
   end
 
   def update_param(nil, _value) do

--- a/lib/bot_state/bot_state.ex
+++ b/lib/bot_state/bot_state.ex
@@ -41,7 +41,8 @@ defmodule BotState do
       informational_settings: %{
         controller_version: Fw.version,
         private_ip: nil,
-        throttled: get_throttled
+        throttled: get_throttled,
+        locked: false
       },
       authorization: %{
         token: nil,

--- a/lib/bot_state/bot_state.ex
+++ b/lib/bot_state/bot_state.ex
@@ -203,8 +203,13 @@ defmodule BotState do
           Map.put(state, :authorization, auth)
           |> Map.put(:informational_settings, new_info)
         }
+      # If the bot is faster than your router (often) this can happen.
+      {:error, "enetunreach"} ->
+        Logger.warn("Something super weird happened.. Probably a race condition.")
+        # Just crash ourselves and try again.
+        {:crash, state}
       error ->
-        Logger.error("Something bad happened: #{inspect error}")
+        Logger.error("Something bad happened when logging in!: #{inspect error}")
         Fw.factory_reset
         {:noreply, state}
       end

--- a/lib/bot_sync/bot_sync.ex
+++ b/lib/bot_sync/bot_sync.ex
@@ -38,7 +38,7 @@ defmodule BotSync do
   end
 
   def handle_cast(:sync, %{token: token, resources: old, corpuses: oldc}) do
-    server = Map.get(token, "unencoded") |> Map.get("iss")
+    "//" <> server = Map.get(token, "unencoded") |> Map.get("iss")
     auth = Map.get(token, "encoded")
 
     case HTTPotion.get "#{server}/api/sync",

--- a/lib/bot_sync/bot_sync.ex
+++ b/lib/bot_sync/bot_sync.ex
@@ -24,6 +24,7 @@ defmodule BotSync do
         old
       _ -> []
     end
+    # []
   end
 
   def load_old_resources do
@@ -83,7 +84,7 @@ defmodule BotSync do
        SafeStorage.write(__MODULE__.Corpuses, :erlang.term_to_binary(oldc))
        {:noreply, %{token: token, resources: new_merged, corpuses: oldc }}
      error ->
-       Logger.debug("Couldn't get resources: #{error}")
+       Logger.debug("Couldn't get resources: #{inspect error}")
        RPC.MessageHandler.log("Error syncing: #{inspect error}", [:error_toast], ["BotSync"])
        {:noreply, %{token: token, resources: old, corpuses: oldc}}
     end

--- a/lib/bot_sync/bot_sync.ex
+++ b/lib/bot_sync/bot_sync.ex
@@ -143,7 +143,7 @@ defmodule BotSync do
         m.create_instruction_set(c)
         {:reply, Module.concat(SiS, "Corpus_#{id}"),
           %{token: token,
-            resources: resources, corpuses: oldc ++ [Corpus.create(c)] }}
+            resources: resources, corpuses: oldc ++ [c] }}
       _corpuses ->
         {:reply, Module.concat(SiS, "Corpus_#{id}"),
           %{token: token, resources: resources, corpuses: oldc}}

--- a/lib/farmbot_scheduler/farmbot_scheduler.ex
+++ b/lib/farmbot_scheduler/farmbot_scheduler.ex
@@ -143,7 +143,7 @@ defmodule Farmbot.Scheduler do
 
   # a regimen has completed items
   # TODO: this should be renamed
-  def handle_info({:done, {:regimen_items,
+  def handle_info({:update, {:regimen,
       {pid, regimen, finished_items, start_time, flag}}}, state)
   do
     # find the index of this regimen in the list.
@@ -152,7 +152,6 @@ defmodule Farmbot.Scheduler do
     end)
     cond do
       is_integer(found) ->
-        # Just update this regimen in the list.
         {:noreply, %State{state | regimens: List.update_at(state.regimens, found,
         fn({^pid, ^regimen, _old_items, ^start_time, _flag}) ->
           {pid, regimen, finished_items, start_time, flag}

--- a/lib/farmbot_scheduler/farmbot_scheduler.ex
+++ b/lib/farmbot_scheduler/farmbot_scheduler.ex
@@ -141,8 +141,7 @@ defmodule Farmbot.Scheduler do
     {:noreply, %State{state | regimens: state.regimens -- [reg_tup]}}
   end
 
-  # a regimen has completed items
-  # TODO: this should be renamed
+  # a regimen has changed state, and the scheduler needs to know about it.
   def handle_info({:update, {:regimen,
       {pid, regimen, finished_items, start_time, flag}}}, state)
   do

--- a/lib/farmbot_scheduler/farmbot_scheduler.ex
+++ b/lib/farmbot_scheduler/farmbot_scheduler.ex
@@ -108,7 +108,10 @@ defmodule Farmbot.Scheduler do
           start_time: time,
           status: flag}}
     end)
-    {_pid, cs} = state.current_sequence || {nil, nil}
+    cs = case state.current_sequence do
+      {_, sequence} -> sequence
+      uh -> uh
+    end
     jsonable =
       %{process_info: regimen_info_list,
         current_sequence: cs,

--- a/lib/farmbot_scheduler/farmbot_scheduler.ex
+++ b/lib/farmbot_scheduler/farmbot_scheduler.ex
@@ -29,7 +29,7 @@ defmodule Farmbot.Scheduler do
     @type sequence_list :: list(Sequence.t)
     @type t :: %__MODULE__{
       regimens: regimen_list,
-      current_sequence: {pid, Sequence.t} | nil,
+      current_sequence: {pid, Sequence.t} | nil | :e_stop,
       sequence_log: sequence_list
     }
 
@@ -59,21 +59,41 @@ defmodule Farmbot.Scheduler do
     default_state
   end
 
-  def handle_cast(:e_stop, state) do
-    Logger.warn("E stopping TODO in Farmbot Scheduler")
+  def handle_cast(:e_stop_lock, state) do
+    Logger.warn("E stopping Farmbot Scheduler")
 
     # if there is a sequence running, stop it agressivly
     case state.current_sequence do
-      {pid, _sequence} -> GenServer.stop(pid, :e_stop)
+      {pid, _sequence} ->
+        Logger.debug("Stopping a running sequence")
+        GenServer.stop(pid, :e_stop)
       nil -> nil
+      # i have to put this here because the lazy hack of putting
+      # :e_stop in the current_sequence feild.
+      _ -> nil
     end
 
     # tell all the regimens to pause.
     Enum.each(state.regimens, fn({pid, regimen, items, start_time, flag}) ->
+      Logger.debug("Pausing regimens")
       GenServer.cast(pid, :pause)
     end)
+    # change current_sequence to something that is not a list or nil
+    # so that sequences from the log wont continue to run and
+    # crash all over the place.
+    {:noreply, %State{state | current_sequence: :e_stop}}
+  end
 
-    {:noreply, state}
+  def handle_cast(:e_stop_unlock, state) do
+    Logger.warn("Resuming Farmbot Scheduler")
+    # tell all the regimens to resume.
+    # Maybe a problem? the user might not want to restart EVERY regimen
+    # there might have been regimens that werent paused by e stop?
+    Enum.each(state.regimens, fn({pid, regimen, items, start_time, flag}) ->
+      GenServer.cast(pid, :resume)
+    end)
+    # set current sequence to nil to allow sequences to continue.
+    {:noreply, %State{state | current_sequence: nil}}
   end
 
   def handle_call(:state, _from, state) do
@@ -108,8 +128,11 @@ defmodule Farmbot.Scheduler do
     case find_regimen(regimen, state.regimens) do
       # If we couln't find this regimen in the list.
       nil ->
-        now = Timex.now()
-        start_time = Timex.shift(now, hours: -now.hour, seconds: -now.second)
+        # get the current time (in this timezone)
+        now = Timex.now(BotState.get_config(:timezone))
+
+        # shift the current time into midnight of today
+        start_time = Timex.shift(now, hours: -now.hour, minutes: -now.minute, seconds: -now.second)
         {:ok, pid} = Regimen.VM.start_link(regimen, [], start_time)
         reg_tup = {pid, regimen, [], start_time, :normal}
         {:reply, :starting, %State{state | regimens: current ++ [reg_tup]}}
@@ -161,6 +184,12 @@ defmodule Farmbot.Scheduler do
                       finished regimen items on #{regimen.name}")
         {:noreply, state}
     end
+  end
+
+  # if we are in e_stop mode just wait
+  def handle_info(:tick, %State{current_sequence: :e_stop} = state) do
+    tick
+    {:noreply, state}
   end
 
   # Tick when the log is empty, ther is no running sequence.
@@ -235,19 +264,40 @@ defmodule Farmbot.Scheduler do
   @doc """
     Safely E stops things that need to be E stopped.
   """
-  @spec e_stop :: :ok
-  def e_stop do
-    GenServer.cast(__MODULE__, :e_stop)
+  @spec e_stop_lock :: :ok
+  def e_stop_lock do
+    GenServer.cast(__MODULE__, :e_stop_lock)
+  end
+
+  @spec e_stop_unlock :: :ok
+  def e_stop_unlock do
+    GenServer.cast(__MODULE__, :e_stop_unlock)
   end
 
   def terminate(:normal, _state) do
     Logger.debug("Farmbot Scheduler died. This is not good.")
   end
 
+  # if the scheduler dies for a non normal reason
+  # We need to make sure to clean up.
+  # if a sequence is running make sure to stop it.
+  # stop all regimens so they are not orphaned.
   def terminate(reason, state) do
     Logger.error("Farmbot Scheduler died. This is not good.")
     spawn fn -> RPC.MessageHandler.send_status end
-    Logger.debug("REASON: #{inspect reason}")
-    Logger.debug("STATE: #{inspect state}")
+    Logger.debug("Reason: #{inspect reason}")
+    # stop a sequence if one is running
+    case state.current_sequence do
+      {pid, _} -> GenServer.stop(pid, :e_stop)
+      nil -> nil
+      # i have to put this here because the lazy hack of putting
+      # :e_stop in the current_sequence feild.
+      _ -> nil
+    end
+
+    # Stop running regimens
+    Enum.each(state.regimens, fn({pid,_,_,_,_}) ->
+      GenServer.stop(pid, :e_stop)
+    end)
   end
 end

--- a/lib/farmbot_scheduler/regimen/regimen_vm.ex
+++ b/lib/farmbot_scheduler/regimen/regimen_vm.ex
@@ -132,7 +132,7 @@ defmodule Regimen.VM  do
     timer = Process.send_after(self(), :tick, @checkup_time)
     finished = ran_items ++ items_to_do
     # tell farmevent manager that these items are done.
-    send(Farmbot.Scheduler, {:done, {:regimen_items, {self(), regimen, finished, start_time, :normal}}})
+    send(Farmbot.Scheduler, {:update, {:regimen, {self(), regimen, finished, start_time, :normal}}})
     {:noreply,
       %State{flag: :normal, timer: timer, start_time: start_time,
         regimen_items: remaining_items, ran_items: finished,

--- a/lib/farmbot_scheduler/regimen/regimen_vm.ex
+++ b/lib/farmbot_scheduler/regimen/regimen_vm.ex
@@ -154,7 +154,7 @@ defmodule Regimen.VM  do
     GenServer.call(pid, :get_info)
   end
 
-  def get_regimen_item_for_regimen(regimen) do
+  def get_regimen_item_for_regimen(%Regimen{} = regimen) do
     BotSync.get_regimen_items
     |> Enum.filter(fn(item) -> item.regimen_id == regimen.id end)
   end

--- a/lib/farmbot_scheduler/regimen/regimen_vm.ex
+++ b/lib/farmbot_scheduler/regimen/regimen_vm.ex
@@ -29,7 +29,7 @@ defmodule Regimen.VM  do
   end
 
   @spec init({Regimen.t, list(RegimenItem.t), DateTime.t}) :: {:ok, map}
-  def init({regimen, finished_items, time}) do
+  def init({%Regimen{} = regimen, finished_items, time}) do
     items = get_regimen_item_for_regimen(regimen)
     first = List.first(items)
     first_time = Timex.shift(time, milliseconds: first.time_offset)

--- a/lib/farmbot_scheduler/regimen/regimen_vm.ex
+++ b/lib/farmbot_scheduler/regimen/regimen_vm.ex
@@ -73,8 +73,7 @@ defmodule Regimen.VM  do
       regimen: regimen
     })
   do
-    #TODO: Someone remind me to rename this send. 
-    send(Farmbot.Scheduler, {:done, {:regimen_items, {self(), regimen, ran, start_time, :paused}}})
+    send(Farmbot.Scheduler, {:update, {:regimen, {self(), regimen, ran, start_time, :paused}}})
     {:noreply, %State{
         flag: :paused,
         timer: timer,

--- a/lib/farmbot_scheduler/regimen/regimen_vm.ex
+++ b/lib/farmbot_scheduler/regimen/regimen_vm.ex
@@ -31,7 +31,7 @@ defmodule Regimen.VM  do
   @spec init({Regimen.t, list(RegimenItem.t), DateTime.t}) :: {:ok, map}
   def init({%Regimen{} = regimen, finished_items, time}) do
     items = get_regimen_item_for_regimen(regimen)
-    first = List.first(items)
+    first = List.first(items -- finished_items)
     first_time = Timex.shift(time, milliseconds: first.time_offset)
 
     # Remove this one day

--- a/lib/farmbot_scheduler/regimen/regimen_vm.ex
+++ b/lib/farmbot_scheduler/regimen/regimen_vm.ex
@@ -59,6 +59,32 @@ defmodule Regimen.VM  do
     {:reply, state, state}
   end
 
+  def handle_cast(:pause, state) do
+    {:noreply, %{state | flag: :paused}}
+  end
+
+  # if the regimen is paused
+  def handle_info(:tick, %State{
+      flag: :paused,
+      timer: timer,
+      start_time: start_time,
+      regimen_items: ri,
+      ran_items: ran,
+      regimen: regimen
+    })
+  do
+    #TODO: Someone remind me to rename this send. 
+    send(Farmbot.Scheduler, {:done, {:regimen_items, {self(), regimen, ran, start_time, :paused}}})
+    {:noreply, %State{
+        flag: :paused,
+        timer: timer,
+        start_time: start_time,
+        regimen_items: ri,
+        ran_items: ran,
+        regimen: regimen
+      }}
+  end
+
   # if there are no more items to run. exit this instance
   def handle_info(:tick, %State{
       flag: _,

--- a/lib/farmbot_scheduler/sequence/sequence_instruction_set_0.ex
+++ b/lib/farmbot_scheduler/sequence/sequence_instruction_set_0.ex
@@ -1,6 +1,6 @@
 defmodule SequenceInstructionSet_0 do
   require Logger
-  def create_instruction_set(%{"tag" => 0, "args" => allowed_args_list, "nodes" => allowed_nodes_list}) do
+  def create_instruction_set(%Corpus{tag: 0, args: args, nodes: nodes}) do
     initial =
       "
       defmodule Corpus_0 do
@@ -50,7 +50,7 @@ defmodule SequenceInstructionSet_0 do
           :error
         end
       "
-    Module.create(SiS, create_instructions(initial, allowed_args_list, allowed_nodes_list ), Macro.Env.location(__ENV__))
+    Module.create(SiS, create_instructions(initial, args, nodes ), Macro.Env.location(__ENV__))
   end
 
   def create_instructions(initial, arg_list, node_list) when is_list(arg_list) and is_list(node_list) do

--- a/lib/serial/gcode_handler.ex
+++ b/lib/serial/gcode_handler.ex
@@ -120,6 +120,10 @@ defmodule Gcode.Handler do
     :ok
   end
 
+  def terminate(_, _state) do
+    :ok
+  end
+
   def block(timeout) do
     receive do
       :done -> :done

--- a/mix.exs
+++ b/mix.exs
@@ -87,8 +87,8 @@ defmodule Fw.Mixfile do
     [
      {:nerves, "~> 0.3.0"},
      {:nerves_firmware_http, github: "nerves-project/nerves_firmware_http"},
-     {:farmbot_configurator, github: "Farmbot/farmbot_configurator"}
-    #  {:farmbot_configurator, path: "../farmbot_configurator"}
+    #  {:farmbot_configurator, github: "Farmbot/farmbot_configurator"}
+     {:farmbot_configurator, path: "../farmbot_configurator"}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -87,8 +87,8 @@ defmodule Fw.Mixfile do
     [
      {:nerves, "~> 0.3.0"},
      {:nerves_firmware_http, github: "nerves-project/nerves_firmware_http"},
-    #  {:farmbot_configurator, github: "Farmbot/farmbot_configurator"}
-     {:farmbot_configurator, path: "../farmbot_configurator"}
+     {:farmbot_configurator, github: "Farmbot/farmbot_configurator"}
+    #  {:farmbot_configurator, path: "../farmbot_configurator"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -15,7 +15,7 @@
   "exrm": {:hex, :exrm, "1.0.8", "5aa8990cdfe300282828b02cefdc339e235f7916388ce99f9a1f926a9271a45d", [:mix], [{:relx, "~> 3.5", [hex: :relx, optional: false]}]},
   "fake_nerves": {:git, "https://github.com/ConnorRigby/fake_nerves.git", "0ffd1df5f4a823257c1c5966d74cd1b26263b2a9", []},
   "farmbot_auth": {:git, "https://github.com/Farmbot/farmbot_auth.git", "97f003ee4f241c65a6f4f835e9db733c84c7f477", []},
-  "farmbot_configurator": {:git, "https://github.com/Farmbot/farmbot_configurator.git", "1fb13c087859659dcf189b814c2bc4c4c3ea5b53", []},
+  "farmbot_configurator": {:git, "https://github.com/Farmbot/farmbot_configurator.git", "02ba0c42e286acc10660d913f5ab720add91e3a9", []},
   "gen_stage": {:hex, :gen_stage, "0.8.0", "a76e3f0530f86fae8b8a1021c06527b1ec171cf4c0bdfecd8d5ad0376d1205af", [:mix], []},
   "getopt": {:hex, :getopt, "0.8.2", "b17556db683000ba50370b16c0619df1337e7af7ecbf7d64fbf8d1d6bce3109b", [:rebar], []},
   "gettext": {:hex, :gettext, "0.12.1", "c0624f52763469ef7a3674919ae28b8286d88195b90fa1516180f31bbbd26d14", [:mix], []},


### PR DESCRIPTION
# What's new?
 * Regimens should persist reboots fairly reliably. (still finding edge cases)
 * e stopping is more of a toggle/mode/state now than a one off command
 * fixed a nasty race condition that would cause the bot to factory reset itself if the bot tried to get a token before PHY was completely up

# What's next?
 * quite a few new race conditions relating to the Arduino and MQTT that need to be sorted.
 *  State persistance is hard