### PR TITLE
Feature/gpio start sequence

### DIFF
--- a/config/target/rpi3.ex
+++ b/config/target/rpi3.ex
@@ -1,0 +1,5 @@
+use Mix.Config
+
+# We need a special fwup conf for the initial v6 release.
+# TODO Remove this some day.
+config :nerves, :firmware, fwup_conf: "fwup_interim.conf"

--- a/lib/farmbot/bot_state/bot_state.ex
+++ b/lib/farmbot/bot_state/bot_state.ex
@@ -105,6 +105,7 @@ defmodule Farmbot.BotState do
             location_data: %{
               position: %{x: -1, y: -1, z: -1}
             },
+            gpio_registry: %{},
             pins: %{},
             configuration: %{},
             informational_settings: %{
@@ -345,6 +346,12 @@ defmodule Farmbot.BotState do
 
   defp do_handle([{:config, _, _, _} | rest], state) do
     do_handle(rest, state)
+  end
+
+  # This one is special because it sends the _entire_ sub tree, not just
+  # Parts of it.
+  defp do_handle([{:gpio_registry, gpio_registry} | rest], state) do
+    do_handle(rest, %{state | gpio_registry: gpio_registry})
   end
 
   defp do_handle([{key, diff} | rest], state) do

--- a/lib/farmbot/bot_state/bot_state.ex
+++ b/lib/farmbot/bot_state/bot_state.ex
@@ -228,7 +228,7 @@ defmodule Farmbot.BotState do
     {
       :producer_consumer,
       struct(__MODULE__, configuration: Map.delete(settings, "user_env"), user_env: user_env),
-      subscribe_to: [Farmbot.Firmware, Farmbot.System.ConfigStorage.Dispatcher],
+      subscribe_to: [Farmbot.Firmware, Farmbot.System.ConfigStorage.Dispatcher, Farmbot.System.GPIO],
       dispatcher: GenStage.BroadcastDispatcher
     }
   end

--- a/lib/farmbot/celery_script/ast/node/register_gpio.ex
+++ b/lib/farmbot/celery_script/ast/node/register_gpio.ex
@@ -13,8 +13,8 @@ defmodule Farmbot.CeleryScript.AST.Node.RegisterGpio do
     case seq do
       nil -> {:error, "Could not find sequence by id: #{id}", env}
       seq ->
-        Logger.busy 1, "Registering: #{pin_num} to sequence: #{seq.name}"
-        case Farmbot.System.GPIO.register_sequence(pin_num, id) do
+        Logger.busy 1, "Registering gpio: #{pin_num} to sequence: #{seq.name}"
+        case Farmbot.System.GPIO.register_pin(pin_num, id) do
           :ok -> {:ok, env}
           {:error, reason} -> {:error, reason, env}
         end

--- a/lib/farmbot/celery_script/ast/node/register_gpio.ex
+++ b/lib/farmbot/celery_script/ast/node/register_gpio.ex
@@ -1,0 +1,23 @@
+defmodule Farmbot.CeleryScript.AST.Node.RegisterGpio do
+  @moduledoc false
+  use Farmbot.CeleryScript.AST.Node
+  allow_args [:sequence_id, :pin_number]
+  use Farmbot.Logger
+
+  import Ecto.Query
+
+  def execute(%{sequence_id: id, pin_number: pin_num}, _, env) do
+    env = mutate_env(env)
+    repo = Farmbot.Repo.current_repo()
+    seq = repo.one(from s in Farmbot.Repo.Sequence, where: s.id == ^id)
+    case seq do
+      nil -> {:error, "Could not find sequence by id: #{id}", env}
+      seq ->
+        Logger.busy 1, "Registering: #{pin_num} to sequence: #{seq.name}"
+        case Farmbot.System.GPIO.register_sequence(pin_num, id) do
+          :ok -> {:ok, env}
+          {:error, reason} -> {:error, reason, env}
+        end
+    end
+  end
+end

--- a/lib/farmbot/celery_script/ast/node/unregister_gpio.ex
+++ b/lib/farmbot/celery_script/ast/node/unregister_gpio.ex
@@ -1,0 +1,14 @@
+defmodule Farmbot.CeleryScript.AST.Node.UnregisterGpio do
+  @moduledoc false
+  use Farmbot.CeleryScript.AST.Node
+  allow_args [:pin_number]
+  use Farmbot.Logger
+
+  def execute(%{pin_number: pin_num}, _, env) do
+    env = mutate_env(env)
+    case Farmbot.System.GPIO.unregister_pin(pin_num)do
+      :ok -> {:ok, env}
+      {:error, reason} -> {:error, reason, env}
+    end
+  end
+end

--- a/lib/farmbot/system/config_storage/gpio_registry.ex
+++ b/lib/farmbot/system/config_storage/gpio_registry.ex
@@ -1,0 +1,20 @@
+defmodule Farmbot.System.ConfigStorage.GpioRegistry do
+  @moduledoc "Union between device (linux) pin and Farmbot Sequence."
+
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias Farmbot.System.ConfigStorage.GpioRegistry
+
+  schema "gpio_registry" do
+    field(:pin, :integer)
+    field(:sequence_id, :integer)
+  end
+
+  @required_fields [:pin, :sequence_id]
+
+  def changeset(%GpioRegistry{} = gpio, params \\ %{}) do
+    gpio
+    |> cast(params, @required_fields)
+    |> validate_required(@required_fields)
+  end
+end

--- a/lib/farmbot/system/gpio/gpio.ex
+++ b/lib/farmbot/system/gpio/gpio.ex
@@ -1,3 +1,61 @@
 defmodule Farmbot.System.GPIO do
   @moduledoc "Handles GPIO inputs."
+  use GenStage
+  use Farmbot.Logger
+
+  @handler Application.get_env(:farmbot, :behaviour)[:gpio_handler]
+
+  @doc "Register a pin number to execute sequence."
+  def register_sequence(pin_num, sequence_id) do
+    GenStage.call(__MODULE__, {:register_sequence, pin_num, sequence_id})
+  end
+
+  @doc false
+  def start_link do
+    GenStage.start_link(__MODULE__, [], [name: __MODULE__])
+  end
+
+  defmodule State do
+    @moduledoc false
+    defstruct [registered: %{}, handler: nil]
+  end
+
+  def init([]) do
+    case @handler.start_link() do
+      {:ok, handler} ->
+        {:producer_consumer, struct(State, [handler: handler]), subscribe_to: [handler], dispatcher: GenStage.BroadcastDispatcher}
+      err -> err
+    end
+  end
+
+  def handle_events(pin_triggers, _from, state) do
+    t = Enum.uniq(pin_triggers)
+    IO.puts "Got triggers: #{inspect t}"
+    for {pin, _} <- t do
+      sequence_id = state.registered[pin]
+      if sequence_id do
+        Logger.busy 1, "Starting Sequence: #{sequence_id} from pin: #{pin}"
+        Farmbot.CeleryScript.AST.Node.Execute.execute(%{sequence_id: sequence_id}, [], struct(Macro.Env, []))
+      else
+        Logger.warn 3, "No sequence assosiated with: #{pin}"
+      end
+    end
+    {:noreply, [], state}
+  end
+
+  def handle_call({:register_sequence, pin_num, sequence_id}, _from, state) do
+    case @handler.register_pin(pin_num) do
+      :ok -> {:reply, :ok, [], %{state | registered: Map.put(state.registered, pin_num, sequence_id)}}
+      {:error, _} = err -> {:reply, err, [], state}
+    end
+  end
+
+  def terminate(reason, state) do
+    if state.handler do
+      if Process.alive?(state.handler) do
+        GenStage.stop(state.handler, reason)
+      end
+    end
+  end
+
 end

--- a/lib/farmbot/system/gpio/gpio.ex
+++ b/lib/farmbot/system/gpio/gpio.ex
@@ -31,7 +31,7 @@ defmodule Farmbot.System.GPIO do
   def handle_events(pin_triggers, _from, state) do
     t = Enum.uniq(pin_triggers)
     IO.puts "Got triggers: #{inspect t}"
-    for {pin, _} <- t do
+    for {:pin_trigger, pin} <- t do
       sequence_id = state.registered[pin]
       if sequence_id do
         Logger.busy 1, "Starting Sequence: #{sequence_id} from pin: #{pin}"

--- a/lib/farmbot/system/gpio/gpio.ex
+++ b/lib/farmbot/system/gpio/gpio.ex
@@ -1,0 +1,3 @@
+defmodule Farmbot.System.GPIO do
+  @moduledoc "Handles GPIO inputs."
+end

--- a/lib/farmbot/system/gpio/gpio.ex
+++ b/lib/farmbot/system/gpio/gpio.ex
@@ -30,7 +30,6 @@ defmodule Farmbot.System.GPIO do
 
   def handle_events(pin_triggers, _from, state) do
     t = Enum.uniq(pin_triggers)
-    IO.puts "Got triggers: #{inspect t}"
     for {:pin_trigger, pin} <- t do
       sequence_id = state.registered[pin]
       if sequence_id do

--- a/lib/farmbot/system/gpio/handler.ex
+++ b/lib/farmbot/system/gpio/handler.ex
@@ -1,3 +1,9 @@
 defmodule Farmbot.System.GPIO.Handler do
   @moduledoc "Behaviour for GPIO handlers to implement."
+
+  @doc "Start the handler."
+  @callback start_link :: GenServer.on_start
+
+  @doc "Register a pin."
+  @callback register_pin(integer) :: :ok | {:error, term}
 end

--- a/lib/farmbot/system/gpio/handler.ex
+++ b/lib/farmbot/system/gpio/handler.ex
@@ -6,4 +6,7 @@ defmodule Farmbot.System.GPIO.Handler do
 
   @doc "Register a pin."
   @callback register_pin(integer) :: :ok | {:error, term}
+
+  @doc "Unregister a pin."
+  @callback unregister_pin(integer) :: :ok | {:error, term}
 end

--- a/lib/farmbot/system/gpio/handler.ex
+++ b/lib/farmbot/system/gpio/handler.ex
@@ -1,0 +1,3 @@
+defmodule Farmbot.System.GPIO.Handler do
+  @moduledoc "Behaviour for GPIO handlers to implement."
+end

--- a/lib/farmbot/system/gpio/stub_handler.ex
+++ b/lib/farmbot/system/gpio/stub_handler.ex
@@ -11,6 +11,10 @@ defmodule Farmbot.System.GPIO.StubHandler do
     GenStage.call(__MODULE__, {:register_pin, num})
   end
 
+  def unregister_pin(num) do
+    GenStage.call(__MODULE__, {:unregister_pin, num})
+  end
+
   def start_link do
     GenStage.start_link(__MODULE__, [], [name: __MODULE__])
   end
@@ -25,6 +29,10 @@ defmodule Farmbot.System.GPIO.StubHandler do
 
   def handle_call({:register_pin, num}, _from, state) do
     {:reply, :ok, [], Map.put(state, num, :enabled)}
+  end
+
+  def handle_call({:unregister_pin, num}, _from, state) do
+    {:reply, :ok, [], Map.delete(state, num)}
   end
 
   def handle_call({:test_fire, pin}, _from, state) do

--- a/lib/farmbot/system/gpio/stub_handler.ex
+++ b/lib/farmbot/system/gpio/stub_handler.ex
@@ -1,4 +1,42 @@
 defmodule Farmbot.System.GPIO.StubHandler do
   @moduledoc "Stub for handling GPIO."
   @behaviour Farmbot.System.GPIO.Handler
+  use GenStage
+
+  def test_fire(pin) do
+    GenStage.call(__MODULE__, {:test_fire, pin})
+  end
+
+  def register_pin(num) do
+    GenStage.call(__MODULE__, {:register_pin, num})
+  end
+
+  def start_link do
+    GenStage.start_link(__MODULE__, [], [name: __MODULE__])
+  end
+
+  def init([]) do
+    {:producer, %{}, [dispatcher: GenStage.BroadcastDispatcher]}
+  end
+
+  def handle_demand(_amnt, state) do
+    {:noreply, [], state}
+  end
+
+  def handle_call({:register_pin, num}, _from, state) do
+    {:reply, :ok, [], Map.put(state, num, :enabled)}
+  end
+
+  def handle_call({:test_fire, pin}, _from, state) do
+    case state[pin] do
+      nil -> {:reply, :error, [], state}
+      :enabled ->
+        send self(), {:do_test_fire, pin}
+        {:reply, :ok, [], state}
+    end
+  end
+
+  def handle_info({:do_test_fire, pin}, state) do
+    {:noreply, [{:pin_trigger, pin}], state}
+  end
 end

--- a/lib/farmbot/system/gpio/stub_handler.ex
+++ b/lib/farmbot/system/gpio/stub_handler.ex
@@ -1,0 +1,4 @@
+defmodule Farmbot.System.GPIO.StubHandler do
+  @moduledoc "Stub for handling GPIO."
+  @behaviour Farmbot.System.GPIO.Handler
+end

--- a/lib/farmbot/system/supervisor.ex
+++ b/lib/farmbot/system/supervisor.ex
@@ -23,7 +23,8 @@ defmodule Farmbot.System.Supervisor do
       |> Enum.map(fn child -> fb_init(child, [[], [name: child]]) end)
 
     after_init_children = [
-      supervisor(Farmbot.System.Updates, [])
+      supervisor(Farmbot.System.Updates, []),
+      worker(Farmbot.System.GPIO, [])
     ]
 
     supervise(before_init_children ++ init_mods ++ after_init_children, strategy: :one_for_all)

--- a/mix.exs
+++ b/mix.exs
@@ -124,6 +124,7 @@ defmodule Farmbot.Mixfile do
         {:nerves_firmware_ssh, "~> 0.2"},
         {:nerves_network, "~> 0.3", github: "nerves-project/nerves_network", override: true},
         {:dhcp_server, github: "nerves-project/dhcp_server", branch: "elixirize-go!", override: true},
+        {:elixie_ale, ">= 0.0"}
         # {:nerves_init_gadget, github: "nerves-project/nerves_init_gadget", branch: "dhcp", only: :dev},
       ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule Farmbot.Mixfile do
   end
 
   def application do
-    [mod: {Farmbot, []}, extra_applications: [:logger, :eex, :ssl, :inets]]
+    [mod: {Farmbot, []}, extra_applications: [:logger, :eex, :ssl, :inets, :runtime_tools]]
   end
 
   defp docs do
@@ -124,8 +124,7 @@ defmodule Farmbot.Mixfile do
         {:nerves_firmware_ssh, "~> 0.2"},
         {:nerves_network, "~> 0.3", github: "nerves-project/nerves_network", override: true},
         {:dhcp_server, github: "nerves-project/dhcp_server", branch: "elixirize-go!", override: true},
-        {:elixie_ale, ">= 0.0"}
-        # {:nerves_init_gadget, github: "nerves-project/nerves_init_gadget", branch: "dhcp", only: :dev},
+        {:elixir_ale, "~> 1.0"}
       ]
   end
 

--- a/mix.lock.rpi0
+++ b/mix.lock.rpi0
@@ -14,6 +14,7 @@
   "distillery": {:hex, :distillery, "1.5.2", "eec18b2d37b55b0bcb670cf2bcf64228ed38ce8b046bb30a9b636a6f5a4c0080", [], [], "hexpm"},
   "dns": {:hex, :dns, "1.0.1", "1d88187fdf564d937cee202949141090707fd0c9d7fcae903a6878ef24ef5d1e", [], [{:socket, "~> 0.3.12", [hex: :socket, repo: "hexpm", optional: false]}], "hexpm"},
   "ecto": {:hex, :ecto, "2.2.6", "3fd1067661d6d64851a0d4db9acd9e884c00d2d1aa41cc09da687226cf894661", [], [{:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
+  "elixir_ale": {:hex, :elixir_ale, "1.0.1", "2066e467e929c589a873e94befd08133eff32c20ef79db24904160dbd7ba75df", [], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
   "elixir_make": {:hex, :elixir_make, "0.4.0", "992f38fabe705bb45821a728f20914c554b276838433349d4f2341f7a687cddf", [], [], "hexpm"},
   "esqlite": {:hex, :esqlite, "0.2.3", "1a8b60877fdd3d50a8a84b342db04032c0231cc27ecff4ddd0d934485d4c0cd5", [], [], "hexpm"},
   "ex_json_schema": {:hex, :ex_json_schema, "0.5.5", "d8d4c3f47b86c9e634e124d518b290dda82a8b94dcc314e45af10042fc369361", [], [], "hexpm"},

--- a/mix.lock.rpi3
+++ b/mix.lock.rpi3
@@ -14,6 +14,7 @@
   "distillery": {:hex, :distillery, "1.5.2", "eec18b2d37b55b0bcb670cf2bcf64228ed38ce8b046bb30a9b636a6f5a4c0080", [], [], "hexpm"},
   "dns": {:hex, :dns, "1.0.1", "1d88187fdf564d937cee202949141090707fd0c9d7fcae903a6878ef24ef5d1e", [], [{:socket, "~> 0.3.12", [hex: :socket, repo: "hexpm", optional: false]}], "hexpm"},
   "ecto": {:hex, :ecto, "2.2.4", "defde3c8eca385bd86466d2e1491d19e77f9b79ad996dc8e89e4e107f3942f40", [], [{:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
+  "elixir_ale": {:hex, :elixir_ale, "1.0.1", "2066e467e929c589a873e94befd08133eff32c20ef79db24904160dbd7ba75df", [], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
   "elixir_make": {:hex, :elixir_make, "0.4.0", "992f38fabe705bb45821a728f20914c554b276838433349d4f2341f7a687cddf", [], [], "hexpm"},
   "esqlite": {:hex, :esqlite, "0.2.3", "1a8b60877fdd3d50a8a84b342db04032c0231cc27ecff4ddd0d934485d4c0cd5", [], [], "hexpm"},
   "ex_json_schema": {:hex, :ex_json_schema, "0.5.5", "d8d4c3f47b86c9e634e124d518b290dda82a8b94dcc314e45af10042fc369361", [], [], "hexpm"},

--- a/nerves/target/gpio/ale_handler.ex
+++ b/nerves/target/gpio/ale_handler.ex
@@ -1,0 +1,3 @@
+defmodule Farmbot.Target.GPIO.AleHandler do
+  @moduledoc "GPIO handler that uses Elixir.Ale"
+end

--- a/nerves/target/gpio/ale_handler.ex
+++ b/nerves/target/gpio/ale_handler.ex
@@ -1,3 +1,60 @@
 defmodule Farmbot.Target.GPIO.AleHandler do
   @moduledoc "GPIO handler that uses Elixir.Ale"
+
+  use GenStage
+  alias ElixirALE.GPIO
+  @behaviour Farmbot.System.GPIO.Handler
+
+  # GPIO Handler Callbacks
+  def start_link do
+    GenStage.start_link(__MODULE__, [], [name: __MODULE__])
+  end
+
+  def register_pin(num) do
+    GenStage.call(__MODULE__, {:register_pin, num})
+  end
+
+  # GenStage Callbacks
+
+  defmodule State do
+    @moduledoc false
+    defstruct [:pins]
+  end
+
+  defmodule PinState do
+    @moduledoc false
+    defstruct [:pin, :state, :signal]
+  end
+
+  def init([]) do
+    {:producer, struct(State, [pins: %{}]), dispatcher: GenStage.BroadcastDispatcher}
+  end
+
+  def handle_demand(_amnt, state) do
+    {:noreply, [], state}
+  end
+
+  def handle_call({:register_pin, num}, _from, state) do
+    with {:ok, pin} <- GPIO.start_link(num, :input),
+    :ok <- GPIO.set_int(pin, :both) do
+      {:reply, :ok, [], %{state | pins: Map.put(state.pins, num, struct(PinState, [pin: pin, state: nil, signal: :falling]))}}
+    else
+      {:error, _} = err-> {:reply, err, [], state}
+      err -> {:reply, {:error, err}, [], state}
+    end
+  end
+
+  def handle_info({:gpio_interrupt, pin, signal}, state) do
+    pin_state = state.pins[pin]
+    new_state = %{state | pins: %{state.pins | pin => %{pin_state | state: signal}}}
+    if (pin_state.state != signal) && (pin_state.signal == signal) do
+      IO.puts "#{pin_state.state} => #{new_state.pins[pin].state}"
+      {:noreply, [{pin, pin_state}], new_state}
+    else
+      {:noreply, [], new_state}
+    end
+  end
 end
+
+# Farmbot.System.GPIO.start_link()
+# Farmbot.System.GPIO.register_sequence(21, 6)

--- a/nerves/target/gpio/ale_handler.ex
+++ b/nerves/target/gpio/ale_handler.ex
@@ -23,11 +23,11 @@ defmodule Farmbot.Target.GPIO.AleHandler do
 
   defmodule PinState do
     @moduledoc false
-    defstruct [:pin, :state, :signal]
+    defstruct [:pin, :state, :signal, :timer]
   end
 
   def init([]) do
-    {:producer, struct(State, [pins: %{}]), dispatcher: GenStage.BroadcastDispatcher}
+    {:producer, struct(State, [pins: %{}]), [dispatcher: GenStage.BroadcastDispatcher]}
   end
 
   def handle_demand(_amnt, state) do
@@ -36,22 +36,40 @@ defmodule Farmbot.Target.GPIO.AleHandler do
 
   def handle_call({:register_pin, num}, _from, state) do
     with {:ok, pin} <- GPIO.start_link(num, :input),
-    :ok <- GPIO.set_int(pin, :both) do
-      {:reply, :ok, [], %{state | pins: Map.put(state.pins, num, struct(PinState, [pin: pin, state: nil, signal: :falling]))}}
+    :ok <- GPIO.set_int(pin, :rising) do
+      {:reply, :ok, [], %{state | pins: Map.put(state.pins, num, struct(PinState, [pin: pin, state: nil, signal: :rising]))}}
     else
       {:error, _} = err-> {:reply, err, [], state}
       err -> {:reply, {:error, err}, [], state}
     end
   end
 
+  def handle_info({:gpio_interrupt, pin, :rising}, state) do
+    IO.puts "got rising signal. Dispatching: #{pin}"
+    pin_state = state.pins[pin]
+    if pin_state.timer do
+      new_state = %{state | pins: %{state.pins | pin => %{pin_state | state: :rising}}}
+      {:noreply, [], new_state}
+    else
+      timer = Process.send_after(self(), {:gpio_timer, pin}, 5000)
+      new_state = %{state | pins: %{state.pins | pin => %{pin_state | timer: timer, state: :rising}}}
+      {:noreply, [{:pin_trigger, pin}], new_state}
+    end
+  end
+
   def handle_info({:gpio_interrupt, pin, signal}, state) do
     pin_state = state.pins[pin]
     new_state = %{state | pins: %{state.pins | pin => %{pin_state | state: signal}}}
-    if (pin_state.state != signal) && (pin_state.signal == signal) do
-      IO.puts "#{pin_state.state} => #{new_state.pins[pin].state}"
-      {:noreply, [{pin, pin_state}], new_state}
+    {:noreply, [], new_state}
+  end
+
+  def handle_info({:gpio_timer, pin}, state) do
+    pin_state = state.pins[pin]
+    if pin_state do
+      new_pin_state = %{pin_state | timer: nil}
+      {:noreply, [], %{state | pins: %{state.pins | pin => new_pin_state}}}
     else
-      {:noreply, [], new_state}
+      {:noreply, [], state}
     end
   end
 end

--- a/nerves/target/gpio/ale_handler.ex
+++ b/nerves/target/gpio/ale_handler.ex
@@ -45,7 +45,6 @@ defmodule Farmbot.Target.GPIO.AleHandler do
   end
 
   def handle_info({:gpio_interrupt, pin, :rising}, state) do
-    IO.puts "got rising signal. Dispatching: #{pin}"
     pin_state = state.pins[pin]
     if pin_state.timer do
       new_state = %{state | pins: %{state.pins | pin => %{pin_state | state: :rising}}}
@@ -73,6 +72,3 @@ defmodule Farmbot.Target.GPIO.AleHandler do
     end
   end
 end
-
-# Farmbot.System.GPIO.start_link()
-# Farmbot.System.GPIO.register_sequence(21, 6)

--- a/priv/config_storage/migrations/20171130004447_add_gpio_registry.exs
+++ b/priv/config_storage/migrations/20171130004447_add_gpio_registry.exs
@@ -1,0 +1,10 @@
+defmodule Farmbot.System.ConfigStorage.Migrations.AddGpioRegistry do
+  use Ecto.Migration
+
+  def change do
+    create table(:gpio_registry) do
+      add(:pin, :integer)
+      add(:sequence_id, :integer)
+    end
+  end
+end


### PR DESCRIPTION
Allow raspberry pi (or any linux gpio for that matter) to be execute a sequence. Two new celeryscript nodes were added:
* `{kind: "register_gpio", args: {pin_number: integer, sequence_id: integer}}`
* `{kind: "unregister_gpio", args: {pin_number: integer}}`