### PR TITLE
Add options to disable parts of sequences

### DIFF
--- a/lib/farmbot/celery_script/ast/node/sequence.ex
+++ b/lib/farmbot/celery_script/ast/node/sequence.ex
@@ -5,7 +5,9 @@ defmodule Farmbot.CeleryScript.AST.Node.Sequence do
   allow_args [:version, :is_outdated, :label]
 
   def execute(%{version: _, is_outdated: _, label: name}, body, env) do
-    Logger.busy 2, "[#{name}] - Sequence init."
+    if Farmbot.System.ConfigStorage.get_config_value(:bool, "settings", "sequence_init_log") do
+      Logger.busy 2, "[#{name}] - Sequence init."
+    end
     env = mutate_env(env)
     if Farmbot.BotState.locked? do
       Logger.error 1, "[#{name}] - Sequence failed. Bot is locked!"
@@ -16,7 +18,9 @@ defmodule Farmbot.CeleryScript.AST.Node.Sequence do
   end
 
   defp do_reduce([ast | rest], env, name) do
-    Logger.info 2, "[#{name}] - Sequence Executing: #{inspect ast}"
+    if Farmbot.System.ConfigStorage.get_config_value(:bool, "settings", "sequence_body_log") do
+      Logger.info 2, "[#{name}] - Sequence Executing: #{inspect ast}"
+    end
     case Farmbot.CeleryScript.execute(ast, env) do
       {:ok, new_env} -> do_reduce(rest, new_env, name)
       {:error, reason, env} ->
@@ -31,7 +35,9 @@ defmodule Farmbot.CeleryScript.AST.Node.Sequence do
   end
 
   defp do_reduce([], env, name) do
-    Logger.success 2, "[#{name}] - Sequence complete."
+    if Farmbot.System.ConfigStorage.get_config_value(:bool, "settings", "sequence_complete_log") do
+      Logger.success 2, "[#{name}] - Sequence complete."
+    end
     {:ok, env}
   end
 end

--- a/priv/config_storage/migrations/20171130044049_add_sequence_complete_log_option.exs
+++ b/priv/config_storage/migrations/20171130044049_add_sequence_complete_log_option.exs
@@ -1,0 +1,11 @@
+defmodule Farmbot.System.ConfigStorage.Migrations.AddSequenceCompleteLogOption do
+  use Ecto.Migration
+
+  import Farmbot.System.ConfigStorage.MigrationHelpers
+
+  def change do
+    create_settings_config("sequence_init_log",     :bool, true)
+    create_settings_config("sequence_body_log",     :bool, true)
+    create_settings_config("sequence_complete_log", :bool, true)
+  end
+end


### PR DESCRIPTION
Added three new configs for FBOS.

`sequence_init_log`
`sequence_body_log`
`sequence_complete_log`

that all control respective log messages.
NOTE: body only disables the `Logger.info 2, "[#{name}] - Sequence Executing: #{inspect ast}"` message, not logs that happen within the  body.

They all default to true, and logs are disabled when set to false