### PR TITLE
Feature/servo angle

### DIFF
--- a/lib/farmbot/celery_script/ast/node/set_servo_angle.ex
+++ b/lib/farmbot/celery_script/ast/node/set_servo_angle.ex
@@ -1,0 +1,15 @@
+defmodule Farmbot.CeleryScript.AST.Node.SetServoAngle do
+  @moduledoc false
+
+  use Farmbot.CeleryScript.AST.Node
+  allow_args [:pin_number, :pin_value]
+
+  def execute(%{pin_number: pin_number, pin_value: value}, _body, env) do
+    env = mutate_env(env)
+    case Farmbot.Firmware.set_servo_angle(pin_number, value) do
+      :ok -> {:ok, env}
+      {:error, reason} -> {:error, reason, env}
+    end
+  end
+
+end

--- a/lib/farmbot/firmware/firmware.ex
+++ b/lib/farmbot/firmware/firmware.ex
@@ -80,6 +80,11 @@ defmodule Farmbot.Firmware do
     GenStage.call(__MODULE__, {:request_software_version, []}, :infinity)
   end
 
+  @doc "Set angle of a servo pin."
+  def set_servo_angle(pin, value) do
+    GenStage.call(__MODULE__, {:set_servo_angle, [pin, value]}, :infinity)
+  end
+
   @doc "Start the firmware services."
   def start_link do
     GenStage.start_link(__MODULE__, [], name: __MODULE__)

--- a/lib/farmbot/firmware/handler.ex
+++ b/lib/farmbot/firmware/handler.ex
@@ -77,4 +77,7 @@ defmodule Farmbot.Firmware.Handler do
   @doc "Request firmware version."
   @callback request_software_version(handler) :: fw_ret_val
 
+  @doc "Set angle on a servo pin."
+  @callback set_servo_angle(handler, pin, number) :: fw_ret_val
+
 end

--- a/lib/farmbot/firmware/stub_handler.ex
+++ b/lib/farmbot/firmware/stub_handler.ex
@@ -70,6 +70,10 @@ defmodule Farmbot.Firmware.StubHandler do
     GenStage.call(handler, :request_software_version)
   end
 
+  def set_servo_angle(handler, pin, number) do
+    GenStage.call(handler, {:set_servo_angle, pin, number})
+  end
+
   ## GenStage Behaviour
 
   defmodule State do
@@ -163,5 +167,9 @@ defmodule Farmbot.Firmware.StubHandler do
 
   def handle_call(:request_software_version, _, state) do
     {:reply, :ok, [{:report_software_version, "STUBFW"}, :done], state}
+  end
+
+  def handle_call({:set_servo_angle, pin, angle}, _, state) do
+    {:reply, :ok, [], state}
   end
 end

--- a/lib/farmbot/firmware/stub_handler.ex
+++ b/lib/farmbot/firmware/stub_handler.ex
@@ -170,6 +170,6 @@ defmodule Farmbot.Firmware.StubHandler do
   end
 
   def handle_call({:set_servo_angle, pin, angle}, _, state) do
-    {:reply, :ok, [], state}
+    {:reply, :ok, [:done], state}
   end
 end

--- a/lib/farmbot/firmware/uart_handler/uart_handler.ex
+++ b/lib/farmbot/firmware/uart_handler/uart_handler.ex
@@ -68,6 +68,10 @@ defmodule Farmbot.Firmware.UartHandler do
     GenStage.call(handler, :request_software_version)
   end
 
+  def set_servo_angle(handler, pin, number) do
+    GenStage.call(handler, {:set_servo_angle, pin, number})
+  end
+
   ## Private
 
   defmodule State do
@@ -285,6 +289,10 @@ defmodule Farmbot.Firmware.UartHandler do
 
   def handle_call(:request_software_version, _from, state) do
     do_write("F83", state)
+  end
+
+  def handle_call({:set_servo_angle, pin, angle}, _, state) do
+    do_write("F61 P#{pin} V#{angle}", state)
   end
 
   def handle_call(_call, _from, state) do

--- a/lib/mix/tasks/farmbot/gen/celery_script/node.ex
+++ b/lib/mix/tasks/farmbot/gen/celery_script/node.ex
@@ -24,11 +24,10 @@ defmodule Mix.Tasks.Farmbot.Gen.CeleryScript.Node do
         namespace = Module.split(Farmbot.CeleryScript.AST.Node)
         full_mod = [namespace | [module]] |> List.flatten |> Module.concat()
         allow_args = check_args(opts)
-        code = EEx.eval_file(@code_template_path, [module: full_mod |> to_string(), allow_args: allow_args])
-        test = EEx.eval_file(@test_template_path, [module: full_mod |> to_string(), alias_module: module])
+        code = EEx.eval_file(@code_template_path, [module: full_mod |> to_string() |> String.trim_leading("Elixir."), allow_args: allow_args])
+        test = EEx.eval_file(@test_template_path, [module: full_mod |> to_string() |> String.trim_leading("Elixir."), alias_module: module])
         do_write_files(module, full_mod, code, test)
       _ ->
-        # Mix.shell.info [:red, @usage]
         Mix.raise @usage
     end
   end
@@ -65,6 +64,7 @@ defmodule Mix.Tasks.Farmbot.Gen.CeleryScript.Node do
           Mix.raise "#{test_file_path} already exists."
         end
         File.write!(test_file_path, test)
+        Mix.shell.info [:green, "New node; #{code_file_path}"]
 
       _ -> Mix.raise "Invalid module: #{module}"
     end

--- a/lib/mix/tasks/farmbot/gen/celery_script/node.ex
+++ b/lib/mix/tasks/farmbot/gen/celery_script/node.ex
@@ -1,0 +1,73 @@
+defmodule Mix.Tasks.Farmbot.Gen.CeleryScript.Node do
+  @moduledoc "Generate a CeleryScript Node."
+  use Mix.Task
+
+  @usage """
+  usage:
+    mix farmbot.celery_script.gen.node SomeCamelModuleName --args comma,seperated,list,of,args
+  """
+
+  @shortdoc @moduledoc
+  @code_template_path "lib/mix/tasks/farmbot/gen/celery_script/node.ex.eex"
+  @test_template_path "lib/mix/tasks/farmbot/gen/celery_script/node_test.ex.eex"
+
+  @node_path "lib/farmbot/celery_script/ast/node/"
+  @test_path "test/farmbot/celery_script/ast/node/"
+
+  def run([]) do
+    Mix.raise @usage
+  end
+
+  def run(args) do
+    case OptionParser.parse(args) do
+      {opts, [module], _} ->
+        namespace = Module.split(Farmbot.CeleryScript.AST.Node)
+        full_mod = [namespace | [module]] |> List.flatten |> Module.concat()
+        allow_args = check_args(opts)
+        code = EEx.eval_file(@code_template_path, [module: full_mod |> to_string(), allow_args: allow_args])
+        test = EEx.eval_file(@test_template_path, [module: full_mod |> to_string(), alias_module: module])
+        do_write_files(module, full_mod, code, test)
+      _ ->
+        # Mix.shell.info [:red, @usage]
+        Mix.raise @usage
+    end
+  end
+
+  defp check_args(opts) do
+    cs_args = Keyword.get(opts, :args, [])
+    arg_list = String.split(cs_args, ",")
+    allow_args = Enum.map(arg_list, fn(arg) ->
+      a = Macro.camelize(arg)
+      namespace = Module.split(Farmbot.CeleryScript.AST.Arg)
+      full_mod = [namespace | [a]] |> List.flatten |> Module.concat()
+      unless Code.ensure_loaded?(full_mod) do
+        Mix.raise "Unknown arg: #{arg} (#{full_mod})"
+      end
+      String.to_atom(arg)
+    end)
+
+    allow_args
+  end
+
+  defp do_write_files(module, full_mod, code, test) do
+    case Code.eval_string(code) do
+      {{:module, ^full_mod, _, _}, _} ->
+        code_file_name = Macro.underscore(module) <> ".ex"
+        code_file_path = Path.join(@node_path, code_file_name)
+        if File.exists?(code_file_path) do
+          Mix.raise "#{code_file_path} already exists."
+        end
+        File.write!(code_file_path, code)
+
+        test_file_name = Macro.underscore(module) <> "_test.exs"
+        test_file_path = Path.join(@test_path, test_file_name)
+        if File.exists?(test_file_path) do
+          Mix.raise "#{test_file_path} already exists."
+        end
+        File.write!(test_file_path, test)
+
+      _ -> Mix.raise "Invalid module: #{module}"
+    end
+  end
+
+end

--- a/lib/mix/tasks/farmbot/gen/celery_script/node.ex.eex
+++ b/lib/mix/tasks/farmbot/gen/celery_script/node.ex.eex
@@ -1,0 +1,12 @@
+defmodule <%= module %> do
+  @moduledoc false
+
+  use Farmbot.CeleryScript.AST.Node
+  allow_args <%= inspect(allow_args) %>
+
+  def execute(_args, _body, env) do
+    env = mutate_env(env)
+    {:error, "Not implemented", env}
+  end
+
+end

--- a/lib/mix/tasks/farmbot/gen/celery_script/node_test.ex.eex
+++ b/lib/mix/tasks/farmbot/gen/celery_script/node_test.ex.eex
@@ -1,0 +1,11 @@
+defmodule <%= module %>Test do
+  alias <%= module %>
+
+  use FarmbotTestSupport.AST.NodeTestCase, async: false
+
+  test "mutates env", %{env: env} do
+    # This should fail until implemented.
+    {:ok, env} = ConfigUpdate.execute(%{}, [], env)
+    assert_cs_env_mutation(<%= alias_module %>, env)
+  end
+end

--- a/lib/mix/tasks/farmbot/gen/celery_script/node_test.ex.eex
+++ b/lib/mix/tasks/farmbot/gen/celery_script/node_test.ex.eex
@@ -5,7 +5,7 @@ defmodule <%= module %>Test do
 
   test "mutates env", %{env: env} do
     # This should fail until implemented.
-    {:ok, env} = ConfigUpdate.execute(%{}, [], env)
+    {:ok, env} = <%= alias_module %>.execute(%{}, [], env)
     assert_cs_env_mutation(<%= alias_module %>, env)
   end
 end

--- a/test/farmbot/celery_script/ast/node/set_servo_angle_test.exs
+++ b/test/farmbot/celery_script/ast/node/set_servo_angle_test.exs
@@ -1,0 +1,10 @@
+defmodule Farmbot.CeleryScript.AST.Node.SetServoAngleTest do
+  alias Farmbot.CeleryScript.AST.Node.SetServoAngle
+
+  use FarmbotTestSupport.AST.NodeTestCase, async: false
+
+  test "mutates env", %{env: env} do
+    {:ok, env} = ConfigUpdate.execute(%{pin_number: 5, pin_value: 180}, [], env)
+    assert_cs_env_mutation(SetServoAngle, env)
+  end
+end

--- a/test/farmbot/celery_script/ast/node/set_servo_angle_test.exs
+++ b/test/farmbot/celery_script/ast/node/set_servo_angle_test.exs
@@ -4,7 +4,7 @@ defmodule Farmbot.CeleryScript.AST.Node.SetServoAngleTest do
   use FarmbotTestSupport.AST.NodeTestCase, async: false
 
   test "mutates env", %{env: env} do
-    {:ok, env} = ConfigUpdate.execute(%{pin_number: 5, pin_value: 180}, [], env)
+    {:ok, env} = SetServoAngle.execute(%{pin_number: 5, pin_value: 180}, [], env)
     assert_cs_env_mutation(SetServoAngle, env)
   end
 end


### PR DESCRIPTION
Adds new celery_script node
* `{kind: "set_servo_angle", args: {pin_number: 4 | 5, pin_value: 0..360}}`
* new function to `Farmbot.Firmware` behaviour
  * set_servo_angle(self, pin, value)
* New CeleryScript code and test generator. 

This will fix #371 and #372 once released. 