### PR TITLE
Enable opt-in beta updates.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,11 @@ workflows:
 
   deploy_nightly:
     jobs:
+      - firmware:
+          context: org-global
+          filters:
+            branches:
+              only: nightly
       - deploy_firmware:
           context: org-global
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
           command: echo $FWUP_KEY_BASE64 | base64 --decode --ignore-garbage > $NERVES_FW_PRIV_KEY
       - run:
           name: Sign firmware
-          command: fwup -S -s $NERVES_FW_PRIV_KEY -i _build/$MIX_TARGET/$MIX_ENV/nerves/images/farmbot.fw -o artifacts/farmbot-${MIX_TARGET}-v$(cat VERSION)-nightly.fw
+          command: fwup -S -s $NERVES_FW_PRIV_KEY -i _build/$MIX_TARGET/$MIX_ENV/nerves/images/farmbot.fw -o artifacts/farmbot-${MIX_TARGET}-v$(cat VERSION)-beta.fw
       - save_cache:
           key: v3-firmware-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
           paths:
@@ -93,7 +93,7 @@ jobs:
       - restore_cache:
           key: v3-firmware-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
       - run:
-          command: ./ghr -t $GITHUB_TOKEN -u farmbot -r farmbot_os -recreate -prerelease -b "$(cat RELEASE_NOTES)" -c nightly "v$(cat VERSION)-nightly" $PWD/artifacts
+          command: ./ghr -t $GITHUB_TOKEN -u farmbot -r farmbot_os -recreate -prerelease -b "$(cat RELEASE_NOTES)" -c beta "v$(cat VERSION)-beta" $PWD/artifacts
 
 workflows:
   version: 2
@@ -103,21 +103,21 @@ workflows:
           context: org-global
           filters:
             branches:
-              ignore: nightly
+              ignore: beta
       - firmware:
           context: org-global
           filters:
             branches:
-              ignore: nightly
+              ignore: beta
 
-  deploy_nightly:
+  deploy_beta:
     triggers:
       - schedule:
           cron: "0 0 * * *"
           filters:
             branches:
               only:
-                - nightly
+                - beta
     jobs:
       - firmware:
           context: org-global

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,8 @@ workflows:
       - firmware:
           context: org-global
           filters:
-            branchs: ignore nightly
+            branchs:
+              ignore: nightly
   deploy_nightly:
     jobs:
       - firmware:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
           command: echo $FWUP_KEY_BASE64 | base64 --decode --ignore-garbage > $NERVES_FW_PRIV_KEY
       - run:
           name: Sign firmware
-          command: fwup -S -s $NERVES_FW_PRIV_KEY -i _build/$MIX_TARGET/$MIX_ENV/nerves/images/farmbot.fw -o artifacts/farmbot-v${CIRCLE_TAG}.fw
+          command: fwup -S -s $NERVES_FW_PRIV_KEY -i _build/$MIX_TARGET/$MIX_ENV/nerves/images/farmbot.fw -o artifacts/farmbot-${MIX_TARGET}-v${CIRCLE_TAG}.fw
       - save_cache:
           key: v3-firmware-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
           paths:
@@ -93,7 +93,7 @@ jobs:
       - restore_cache:
           key: v3-firmware-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
       - run:
-          command: ./ghr -prerelease -draft -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME -b "$(cat RELEASE_NOTES)" -replace $CIRCLE_TAG-nightly $PWD/artifacts/
+          command: ./ghr -prerelease -draft -t $GITHUB_TOKEN -u farmbot -r farmbot_os -b "$(cat RELEASE_NOTES)" -replace "${CIRCLE_TAG}-nightly" $PWD/artifacts/
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
           command: echo $FWUP_KEY_BASE64 | base64 --decode --ignore-garbage > $NERVES_FW_PRIV_KEY
       - run:
           name: Sign firmware
-          command: fwup -S -s $NERVES_FW_PRIV_KEY -i _build/$MIX_TARGET/$MIX_ENV/nerves/images/farmbot.fw -o artifacts/farmbot-${MIX_TARGET}-v${CIRCLE_TAG}.fw
+          command: fwup -S -s $NERVES_FW_PRIV_KEY -i _build/$MIX_TARGET/$MIX_ENV/nerves/images/farmbot.fw -o artifacts/farmbot-${MIX_TARGET}-v$(cat VERSION)-nightly.fw
       - save_cache:
           key: v3-firmware-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
           paths:
@@ -93,7 +93,7 @@ jobs:
       - restore_cache:
           key: v3-firmware-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
       - run:
-          command: ./ghr -t $GITHUB_TOKEN -u farmbot -r farmbot_os -recreate -prerelease -b "$(cat RELEASE_NOTES)" -c "$(git log --pretty=format:%h -1)" v$(cat VERSION)-nightly $PWD/artifacts
+          command: ./ghr -t $GITHUB_TOKEN -u farmbot -r farmbot_os -recreate -prerelease -b "$(cat RELEASE_NOTES)" -c nightly "v$(cat VERSION)-nightly" $PWD/artifacts
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
       - restore_cache:
           key: v3-firmware-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
       - run:
-          command: ./ghr -t $GITHUB_TOKEN -u farmbot -r farmbot_os -recreate -prerelease -b "$(cat RELEASE_NOTES)" -c "$(git log --pretty=format:%h -1)" "v$(cat VERSION)-beta" $PWD/artifacts
+          command: ./ghr -t $GITHUB_TOKEN -u farmbot -r farmbot_os -recreate -prerelease -b "$(cat RELEASE_NOTES)" -c $(git rev-parse --verify HEAD) "v$(cat VERSION)-beta" $PWD/artifacts
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,7 @@ jobs:
   deploy_firmware:
     <<: *defaults
     steps:
+      - checkout
       - run:
           name: Install dependencies
           command: |
@@ -112,6 +113,8 @@ workflows:
               only: nightly
       - deploy_firmware:
           context: org-global
+          requires:
+            - firmware
           filters:
             branches:
               only: nightly

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,8 @@ workflows:
           context: org-global
       - firmware:
           context: org-global
+  deploy_nightly:
+    jobs:
       - nightly:
           context: org-global
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
             wget https://github.com/tcnksm/ghr/releases/download/v0.5.4/ghr_v0.5.4_linux_amd64.zip
             unzip ghr_v0.5.4_linux_amd64.zip
       - run:
-          command: grep -Pazo "(?s)(?<=## ${CIRCLE_TAG})[^#]+" CHANGELOG.md > RELEASE_NOTES
+          command: grep -Pazo "(?s)(?<=# $(cat VERSION))[^#]+" CHANGELOG.md > RELEASE_NOTES
       - restore_cache:
           key: v3-firmware-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
       - restore_cache:
           key: v3-firmware-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
       - run:
-          command: ./ghr -draft -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME -b "$(cat RELEASE_NOTES)" -replace $CIRCLE_TAG ./artifacts/
+          command: ./ghr -prerelease -draft -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME -b "$(cat RELEASE_NOTES)" -replace $CIRCLE_TAG-nightly $PWD/artifacts/
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
       - restore_cache:
           key: v3-firmware-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
       - run:
-          command: ./ghr -t $GITHUB_TOKEN -u farmbot -r farmbot_os -recreate -prerelease -b "$(cat RELEASE_NOTES)" -c beta "v$(cat VERSION)-beta" $PWD/artifacts
+          command: ./ghr -t $GITHUB_TOKEN -u farmbot -r farmbot_os -recreate -prerelease -b "$(cat RELEASE_NOTES)" -c "$(git log --pretty=format:%h -1)" "v$(cat VERSION)-beta" $PWD/artifacts
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,12 +78,12 @@ workflows:
       - firmware:
           context: org-global
   deploy_nightly:
+    environment:
+      MIX_ENV: prod
+      MIX_TARGET: rpi3
     jobs:
       - firmware:
           context: org-global
-          environment:
-            MIX_ENV: prod
-            MIX_TARGET: rpi3
           filters:
             branches:
               only: nightly

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,6 @@ jobs:
           key: v3-dependency-cache-{{ checksum "mix.lock.host" }}
           paths:
             - _build
-            - deps
             - ~/.mix
             - ~/.nerves
       - run:
@@ -63,11 +62,15 @@ jobs:
           key: v3-dependency-cache-{{ checksum "mix.lock.rpi3" }}
           paths:
             - _build
-            - deps
             - ~/.mix
             - ~/.nerves
       - run: mix firmware.slack --channels C58DCU4A3
-      - run: fwup --sign --private-key $NERVES_FW_PRIV_KEY -i _build/{{ .Environment.MIX_TARGET }}/{{ .Environment.MIX_ENV }}/nerves/images/farmbot.fw -o farmbot-v{{ .Environment.Revision }}.fw
+      - run:
+          name: Decode fwup priv key
+          command: echo $FWUP_KEY_BASE64 | base64 --decode --ignore-garbage > $NERVES_FW_PRIV_KEY
+      - run:
+          name: Sign firmware
+          command: fwup --sign --private-key $NERVES_FW_PRIV_KEY -i _build/{{ .Environment.MIX_TARGET }}/{{ .Environment.MIX_ENV }}/nerves/images/farmbot.fw -o farmbot-v{{ .Environment.Revision }}.fw
       - save_cache:
           key: v3-firmware-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
           paths:
@@ -106,11 +109,6 @@ workflows:
 
   deploy_nightly:
     jobs:
-      - firmware:
-          context: org-global
-          filters:
-            branches:
-              only: nightly
       - deploy_firmware:
           context: org-global
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,9 +78,6 @@ workflows:
       - firmware:
           context: org-global
   deploy_nightly:
-    environment:
-      MIX_ENV: prod
-      MIX_TARGET: rpi3
     jobs:
       - firmware:
           context: org-global

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,16 +111,17 @@ workflows:
               ignore: nightly
 
   deploy_nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - nightly
     jobs:
       - firmware:
           context: org-global
-          filters:
-            branches:
-              only: nightly
       - deploy_firmware:
           context: org-global
           requires:
             - firmware
-          filters:
-            branches:
-              only: nightly

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,11 +70,11 @@ jobs:
           command: echo $FWUP_KEY_BASE64 | base64 --decode --ignore-garbage > $NERVES_FW_PRIV_KEY
       - run:
           name: Sign firmware
-          command: fwup -S -s $NERVES_FW_PRIV_KEY -i _build/{{ .Environment.MIX_TARGET }}/{{ .Environment.MIX_ENV }}/nerves/images/farmbot.fw -o farmbot-v{{ .Environment.Revision }}.fw
+          command: fwup -S -s $NERVES_FW_PRIV_KEY -i _build/$MIX_TARGET/$MIX_ENV/nerves/images/farmbot.fw -o farmbot-v${CIRCLE_TAG}.fw
       - save_cache:
           key: v3-firmware-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
           paths:
-            - farmbot-v{{ .Environment.Revision }}.fw
+            - farmbot-v${CIRCLE_TAG}.fw
 
   deploy_firmware:
     <<: *defaults
@@ -90,7 +90,7 @@ jobs:
       - restore_cache:
           key: v3-firmware-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
       - run:
-          command: ./ghr -draft -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME -b "$(cat RELEASE_NOTES)" -replace $CIRCLE_TAG farmbot-v{{ .Environment.Revision }}.fw
+          command: ./ghr -draft -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME -b "$(cat RELEASE_NOTES)" -replace $CIRCLE_TAG farmbot-v${CIRCLE_TAG}.fw
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
           command: echo $FWUP_KEY_BASE64 | base64 --decode --ignore-garbage > $NERVES_FW_PRIV_KEY
       - run:
           name: Sign firmware
-          command: fwup -S -s $NERVES_FW_PRIV_KEY -i _build/$MIX_TARGET/$MIX_ENV/nerves/images/farmbot.fw -o artifacts/farmbot-${MIX_TARGET}-v$(cat VERSION)-beta.fw
+          command: fwup -S -s $NERVES_FW_PRIV_KEY -i _build/$MIX_TARGET/$MIX_ENV/nerves/images/farmbot.fw -o artifacts/farmbot-${MIX_TARGET}-$(cat VERSION)-beta.fw
       - save_cache:
           key: v3-firmware-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,9 +59,6 @@ jobs:
       - run: mix compile
       - run:
           command: mix firmware
-          environment:
-            MIX_ENV: dev
-            MIX_TARGET: rpi3
       - save_cache:
           key: v3-dependency-cache-{{ checksum "mix.lock.rpi3" }}
           paths:
@@ -71,9 +68,6 @@ jobs:
             - ~/.nerves
       - run:
           command: mix firmware.slack --channels C58DCU4A3
-          environment:
-            MIX_ENV: dev
-            MIX_TARGET: rpi3
 
 workflows:
   version: 2
@@ -83,3 +77,11 @@ workflows:
           context: org-global
       - firmware:
           context: org-global
+      - nightly:
+          context: org-global
+          environment:
+            MIX_ENV: prod
+            MIX_TARGET: rpi3
+          filters:
+            branches:
+              only: nightly

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ workflows:
           context: org-global
   deploy_nightly:
     jobs:
-      - nightly:
+      - firmware:
           context: org-global
           environment:
             MIX_ENV: prod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,10 +66,8 @@ jobs:
             - deps
             - ~/.mix
             - ~/.nerves
-      - run:
-          command: mix firmware.slack --channels C58DCU4A3
-      - run:
-          command: fwup --sign --private-key $NERVES_FW_PRIV_KEY -i _build/{{ .Environment.MIX_TARGET }}/{{ .Environment.MIX_ENV }}/nerves/images/farmbot.fw -o farmbot-v{{ .Environment.Revision }}.fw
+      - run: mix firmware.slack --channels C58DCU4A3
+      - run: fwup --sign --private-key $NERVES_FW_PRIV_KEY -i _build/{{ .Environment.MIX_TARGET }}/{{ .Environment.MIX_ENV }}/nerves/images/farmbot.fw -o farmbot-v{{ .Environment.Revision }}.fw
       - save_cache:
           key: v3-firmware-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
           paths:
@@ -79,16 +77,16 @@ jobs:
     <<: *defaults
     steps:
       - run:
-        name: Install dependencies
-        command: |
-          wget https://github.com/tcnksm/ghr/releases/download/v0.5.4/ghr_v0.5.4_linux_amd64.zip
-          unzip ghr_v0.5.4_linux_amd64.zip
+          name: Install dependencies
+          command: |
+            wget https://github.com/tcnksm/ghr/releases/download/v0.5.4/ghr_v0.5.4_linux_amd64.zip
+            unzip ghr_v0.5.4_linux_amd64.zip
       - run:
-        command: grep -Pazo "(?s)(?<=## ${CIRCLE_TAG})[^#]+" CHANGELOG.md > RELEASE_NOTES
+          command: grep -Pazo "(?s)(?<=## ${CIRCLE_TAG})[^#]+" CHANGELOG.md > RELEASE_NOTES
       - restore_cache:
-        key: v3-firmware-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
+          key: v3-firmware-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
       - run:
-        command: ./ghr -draft -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME -b "$(cat RELEASE_NOTES)" -replace $CIRCLE_TAG farmbot-v{{ .Environment.Revision }}.fw
+          command: ./ghr -draft -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME -b "$(cat RELEASE_NOTES)" -replace $CIRCLE_TAG farmbot-v{{ .Environment.Revision }}.fw
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,15 +66,18 @@ jobs:
             - ~/.nerves
       - run: mix firmware.slack --channels C58DCU4A3
       - run:
+          name: Make artifacts dir
+          command: mkdir -p artifacts
+      - run:
           name: Decode fwup priv key
           command: echo $FWUP_KEY_BASE64 | base64 --decode --ignore-garbage > $NERVES_FW_PRIV_KEY
       - run:
           name: Sign firmware
-          command: fwup -S -s $NERVES_FW_PRIV_KEY -i _build/$MIX_TARGET/$MIX_ENV/nerves/images/farmbot.fw -o farmbot-v${CIRCLE_TAG}.fw
+          command: fwup -S -s $NERVES_FW_PRIV_KEY -i _build/$MIX_TARGET/$MIX_ENV/nerves/images/farmbot.fw -o artifacts/farmbot-v${CIRCLE_TAG}.fw
       - save_cache:
           key: v3-firmware-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
           paths:
-            - farmbot-v${CIRCLE_TAG}.fw
+            - ./artifacts
 
   deploy_firmware:
     <<: *defaults
@@ -90,7 +93,7 @@ jobs:
       - restore_cache:
           key: v3-firmware-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
       - run:
-          command: ./ghr -draft -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME -b "$(cat RELEASE_NOTES)" -replace $CIRCLE_TAG farmbot-v${CIRCLE_TAG}.fw
+          command: ./ghr -draft -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME -b "$(cat RELEASE_NOTES)" -replace $CIRCLE_TAG ./artifacts/
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,27 @@ jobs:
             - ~/.nerves
       - run:
           command: mix firmware.slack --channels C58DCU4A3
+      - run:
+          command: fwup --sign --private-key $NERVES_FW_PRIV_KEY -i _build/{{ .Environment.MIX_TARGET }}/{{ .Environment.MIX_ENV }}/nerves/images/farmbot.fw -o farmbot-v{{ .Environment.Revision }}.fw
+      - save_cache:
+          key: v3-firmware-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
+          paths:
+            - farmbot-v{{ .Environment.Revision }}.fw
+
+  deploy_firmware:
+    <<: *defaults
+    steps:
+      - run:
+        name: Install dependencies
+        command: |
+          wget https://github.com/tcnksm/ghr/releases/download/v0.5.4/ghr_v0.5.4_linux_amd64.zip
+          unzip ghr_v0.5.4_linux_amd64.zip
+      - run:
+        command: grep -Pazo "(?s)(?<=## ${CIRCLE_TAG})[^#]+" CHANGELOG.md > RELEASE_NOTES
+      - restore_cache:
+        key: v3-firmware-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
+      - run:
+        command: ./ghr -draft -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME -b "$(cat RELEASE_NOTES)" -replace $CIRCLE_TAG farmbot-v{{ .Environment.Revision }}.fw
 
 workflows:
   version: 2
@@ -87,6 +108,11 @@ workflows:
   deploy_nightly:
     jobs:
       - firmware:
+          context: org-global
+          filters:
+            branches:
+              only: nightly
+      - deploy_firmware:
           context: org-global
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,17 +111,18 @@ workflows:
               ignore: beta
 
   deploy_beta:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
+    jobs:
+      - firmware:
+          context: org-global
           filters:
             branches:
               only:
                 - beta
-    jobs:
-      - firmware:
-          context: org-global
       - deploy_firmware:
           context: org-global
+          filters:
+            branches:
+              only:
+                - beta
           requires:
             - firmware

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
       - restore_cache:
           key: v3-firmware-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
       - run:
-          command: ./ghr -prerelease -draft -t $GITHUB_TOKEN -u farmbot -r farmbot_os -b "$(cat RELEASE_NOTES)" -replace "${CIRCLE_TAG}-nightly" $PWD/artifacts/
+          command: ./ghr -recreate -prerelease -u farmbot -r farmbot_os -b "$(cat RELEASE_NOTES)" "${CIRCLE_TAG}-nightly" "$PWD/artifacts/"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
       - restore_cache:
           key: v3-firmware-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
       - run:
-          command: ./ghr -recreate -prerelease -u farmbot -r farmbot_os -b "$(cat RELEASE_NOTES)" "${CIRCLE_TAG}-nightly" "$PWD/artifacts/"
+          command: ./ghr -t $GITHUB_TOKEN -u farmbot -r farmbot_os -recreate -prerelease -b "$(cat RELEASE_NOTES)" v$CIRCLE_TAG-nightly $PWD/artifacts
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
           command: echo $FWUP_KEY_BASE64 | base64 --decode --ignore-garbage > $NERVES_FW_PRIV_KEY
       - run:
           name: Sign firmware
-          command: fwup --sign --private-key $NERVES_FW_PRIV_KEY -i _build/{{ .Environment.MIX_TARGET }}/{{ .Environment.MIX_ENV }}/nerves/images/farmbot.fw -o farmbot-v{{ .Environment.Revision }}.fw
+          command: fwup -S -s $NERVES_FW_PRIV_KEY -i _build/{{ .Environment.MIX_TARGET }}/{{ .Environment.MIX_ENV }}/nerves/images/farmbot.fw -o farmbot-v{{ .Environment.Revision }}.fw
       - save_cache:
           key: v3-firmware-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,8 +81,9 @@ workflows:
       - firmware:
           context: org-global
           filters:
-            branchs:
+            branches:
               ignore: nightly
+
   deploy_nightly:
     jobs:
       - firmware:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
       - restore_cache:
           key: v3-firmware-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
       - run:
-          command: ./ghr -t $GITHUB_TOKEN -u farmbot -r farmbot_os -recreate -prerelease -b "$(cat RELEASE_NOTES)" v$CIRCLE_TAG-nightly $PWD/artifacts
+          command: ./ghr -t $GITHUB_TOKEN -u farmbot -r farmbot_os -recreate -prerelease -b "$(cat RELEASE_NOTES)" -c "$(git log --pretty=format:%h -1)" v$(cat VERSION)-nightly $PWD/artifacts
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,8 +75,13 @@ workflows:
     jobs:
       - test:
           context: org-global
+          filters:
+            branches:
+              ignore: nightly
       - firmware:
           context: org-global
+          filters:
+            branchs: ignore nightly
   deploy_nightly:
     jobs:
       - firmware:

--- a/config/target/prod.exs
+++ b/config/target/prod.exs
@@ -64,12 +64,6 @@ config :farmbot, :behaviour,
   update_handler: Farmbot.Target.UpdateHandler,
   gpio_handler:   Farmbot.Target.GPIO.AleHandler
 
-
-config :nerves_firmware_ssh,
-  authorized_keys: [
-    File.read!(Path.join(System.user_home!, ".ssh/id_rsa.pub"))
-  ]
-
 config :nerves_init_gadget,
   address_method: :static
 

--- a/lib/farmbot/celery_script/ast/node/check_updates.ex
+++ b/lib/farmbot/celery_script/ast/node/check_updates.ex
@@ -7,7 +7,7 @@ defmodule Farmbot.CeleryScript.AST.Node.CheckUpdates do
     env = mutate_env(env)
     case Farmbot.System.Updates.check_updates() do
       :ok -> {:ok, env}
-      {:error, reason} -> {:error, reason, env}
+      _ -> {:error, "Failed to check updates", env}
     end
   end
 

--- a/lib/farmbot/celery_script/ast/node/check_updates.ex
+++ b/lib/farmbot/celery_script/ast/node/check_updates.ex
@@ -5,7 +5,7 @@ defmodule Farmbot.CeleryScript.AST.Node.CheckUpdates do
 
   def execute(%{package: :farmbot_os}, _, env) do
     env = mutate_env(env)
-    case Farmbot.System.Updates.check_updates() do
+    case Farmbot.System.Updates.check_updates(true) do
       :ok -> {:ok, env}
       :no_update -> {:ok, env}
       _ -> {:error, "Failed to check updates", env}

--- a/lib/farmbot/celery_script/ast/node/check_updates.ex
+++ b/lib/farmbot/celery_script/ast/node/check_updates.ex
@@ -7,6 +7,7 @@ defmodule Farmbot.CeleryScript.AST.Node.CheckUpdates do
     env = mutate_env(env)
     case Farmbot.System.Updates.check_updates() do
       :ok -> {:ok, env}
+      :no_update -> {:ok, env}
       _ -> {:error, "Failed to check updates", env}
     end
   end

--- a/lib/farmbot/system/updates/update_timer.ex
+++ b/lib/farmbot/system/updates/update_timer.ex
@@ -29,7 +29,8 @@ defmodule Farmbot.System.UpdateTimer do
   end
 
   def handle_info(:checkup, state) do
-    Farmbot.System.Updates.check_updates()
+    osau = Farmbot.System.ConfigStorage.get_config_value(:bool, "settings", "os_auto_update")
+    Farmbot.System.Updates.check_updates(osau)
     Process.send_after(self(), :checkup, @twelve_hours)
     {:noreply, state, :hibernate}
   end

--- a/lib/farmbot/system/updates/update_timer.ex
+++ b/lib/farmbot/system/updates/update_timer.ex
@@ -19,6 +19,10 @@ defmodule Farmbot.System.UpdateTimer do
     GenServer.start_link(__MODULE__, [], [name: __MODULE__])
   end
 
+  def terminate(reason, _) do
+    Logger.error 1, "Failed to check updates: #{inspect reason}"
+  end
+
   def init([]) do
     spawn __MODULE__, :wait_for_http, [self()]
     {:ok, [], :hibernate}

--- a/lib/farmbot/system/updates/updates.ex
+++ b/lib/farmbot/system/updates/updates.ex
@@ -131,6 +131,7 @@ defmodule Farmbot.System.Updates do
     Logger.info 3, "Applying prerelease firmware."
     true
   end
+  
   defp should_apply_update(_, _, true) do
     true
   end

--- a/lib/farmbot/system/updates/updates.ex
+++ b/lib/farmbot/system/updates/updates.ex
@@ -73,6 +73,8 @@ defmodule Farmbot.System.Updates do
         # Logger.info 1, "Downloading update. Here is the release notes"
         # Logger.info 1, cl
         do_download_and_apply(fw_url, new_version)
+      else
+        :no_update
       end
     else
       :error ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,8 +4,7 @@ defmodule Farmbot.Mixfile do
   @version Path.join(__DIR__, "VERSION") |> File.read!() |> String.trim()
 
   defp commit() do
-    {t, _} = System.cmd("git", ["log", "--pretty=format:%h", "-1"])
-    t
+    System.cmd("git", ~w"rev-parse --verify HEAD") |> elem(0) |> String.trim()
   end
 
   Mix.shell().info([

--- a/priv/config_storage/migrations/20180103212728_add_beta_chanel_config.exs
+++ b/priv/config_storage/migrations/20180103212728_add_beta_chanel_config.exs
@@ -1,0 +1,10 @@
+defmodule Farmbot.System.ConfigStorage.Migrations.AddBetaChanelConfig do
+  use Ecto.Migration
+
+  import Farmbot.System.ConfigStorage.MigrationHelpers
+
+  def change do
+    create_settings_config("beta_opt_in", :bool, false)
+    create_settings_config("os_update_server_overwrite", :string, nil)
+  end
+end


### PR DESCRIPTION
Any push to this branch will cause CircleCI to build a fwupdate and push it to the github releases. as a prerelease, overwriting any old release of the same name. This also fixes bugs in the update process that got tested while building this feature. 