### PR TITLE
Fix not being able to connect to hidden networks.

### DIFF
--- a/lib/farmbot/system/config_storage/network_interface.ex
+++ b/lib/farmbot/system/config_storage/network_interface.ex
@@ -16,6 +16,7 @@ defmodule Farmbot.System.ConfigStorage.NetworkInterface do
 
     field(:ipv4_method, :string)
     field(:migrated, :boolean)
+    field(:maybe_hidden, :boolean)
   end
 
   @required_fields [:name, :type]

--- a/nerves/target/bootstrap/configurator/router.ex
+++ b/nerves/target/bootstrap/configurator/router.ex
@@ -118,17 +118,29 @@ defmodule Farmbot.Target.Bootstrap.Configurator.Router do
 
       case settings["type"] do
         "wireless" ->
+          # lol
+          maybe_hidden? = if Map.get(settings, "maybe_hidden", false) do
+            true
+          else
+            false
+          end
+
           %ConfigStorage.NetworkInterface{
             name: iface,
             type: "wireless",
             ssid: Map.fetch!(settings, "ssid"),
             psk: Map.fetch!(settings, "psk"),
             security: "WPA-PSK",
-            ipv4_method: "dhcp"
+            ipv4_method: "dhcp",
+            maybe_hidden: maybe_hidden?
           }
 
         "wired" ->
-          %ConfigStorage.NetworkInterface{name: iface, type: "wired", ipv4_method: "dhcp"}
+          %ConfigStorage.NetworkInterface{
+            name: iface,
+            type: "wired",
+            ipv4_method: "dhcp"
+          }
       end
       |> ConfigStorage.insert!()
     end

--- a/nerves/target/network.ex
+++ b/nerves/target/network.ex
@@ -26,9 +26,9 @@ defmodule Farmbot.Target.Network do
   # TODO Expand this to allow for more settings.
   def to_network_config(config)
 
-  def to_network_config(%NetworkInterface{ssid: ssid, psk: psk, type: "wireless"} = config) do
+  def to_network_config(%NetworkInterface{ssid: ssid, psk: psk, type: "wireless", maybe_hidden: hidden?} = config) do
     Logger.debug(3, "wireless network config: ssid: #{config.ssid}")
-    {config.name, [ssid: ssid, key_mgmt: :"WPA-PSK", psk: psk]}
+    {config.name, [ssid: ssid, key_mgmt: :"WPA-PSK", psk: psk, maybe_hidden: hidden?]}
   end
 
   def to_network_config(%NetworkInterface{type: "wired"} = config) do

--- a/priv/config_storage/migrations/20180308162327_add_maybe_hidden_network_flag.exs
+++ b/priv/config_storage/migrations/20180308162327_add_maybe_hidden_network_flag.exs
@@ -1,0 +1,9 @@
+defmodule Farmbot.System.ConfigStorage.Migrations.AddMaybeHiddenNetworkFlag do
+  use Ecto.Migration
+
+  def change do
+    alter table("network_interfaces") do
+      add(:maybe_hidden, :boolean)
+    end
+  end
+end

--- a/priv/static/templates/network.html.eex
+++ b/priv/static/templates/network.html.eex
@@ -5,6 +5,7 @@
   <title> Configure Farmbot's Network </title>
   <link rel="stylesheet" href="/styles.css">
   <script type="text/javascript">
+
     function ssidSelectOnChange(iface) {
       var elem = document.getElementById(iface + "_ssid_select");
       var selected = elem.options[elem.selectedIndex];
@@ -13,15 +14,19 @@
         replaceSelect(iface);
       }
     }
+
     function replaceSelect(iface) {
-      console.log("Replaceing select element with input element")
-      var elem = document.getElementById(iface + "_ssid_select");
+      console.log("Replaceing select element with input element");
+      var selectElem = document.getElementById(iface + "_ssid_select");
       var inputNode = document.createElement("input");
       inputNode.setAttribute("name", iface + "_ssid");
       inputNode.setAttribute("type", "text");
-      elem.parentNode.insertBefore(inputNode, elem.nextSibling);
-      elem.outerHTML = "";
-      delete elem;
+      selectElem.parentNode.insertBefore(inputNode, selectElem.nextSibling);
+      selectElem.outerHTML = "";
+      delete selectElem;
+
+      var maybeHiddenToggle = document.getElementById(iface + "_maybe_hidden");
+      maybeHiddenToggle.setAttribute("value", "true");
     }
 
     function selectInterface(iface, type) {
@@ -33,6 +38,7 @@
         for(i=0; i<elems.length; i++){ elems[i].setAttribute("hidden", true) }
       }
     }
+
   </script>
 </head>
 
@@ -68,15 +74,23 @@
                 <label>Password</label>
                 <input type=password name="<%= interface %>_psk" />
                 <input hidden=true name="<%= interface %>_type" value="wireless" />
+                <input hidden=true name="<%= interface %>_maybe_hidden" id="<%= interface %>_maybe_hidden" value="false" />
               </fieldset>
           <% end %>
-      <% end %>
+        <% end %>
+
+        <div class="button">
+          <input type=submit value="next">
+        </div>
+
+      </form>
+
+
+
     </div>
   </div>
-  <div class="button">
-    <input type=submit value="next">
-  </div>
-  </form>
+
+
 
 </body>
 


### PR DESCRIPTION
To connect to a hidden wireless network, the client needs
to wait for the wireless beacon before being able to connect
to get the bssid and essid.

* Add flag if the user manually inputs their ssid.
* Add special case for if the network is hidden