### PR TITLE
6.4.1

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -60,7 +60,8 @@ config :farmbot, :farmware,
 
 config :farmbot,
   expected_fw_versions: ["6.4.0.F", "6.4.0.R", "6.4.0.G"],
-  default_server: "https://my.farm.bot"
+  default_server: "https://my.farm.bot",
+  default_currently_on_beta: String.contains?(to_string(:os.cmd('git rev-parse --abbrev-ref HEAD')), "beta")
 
 global_overlay_dir = "rootfs_overlay"
 

--- a/lib/farmbot/firmware/firmware.ex
+++ b/lib/farmbot/firmware/firmware.ex
@@ -137,13 +137,13 @@ defmodule Farmbot.Firmware do
   end
 
   defp needs_home_on_boot do
-    x = get_config_value(:float, "hardware_params", "movement_home_at_boot_x") || 0
+    x = (get_config_value(:float, "hardware_params", "movement_home_at_boot_x") || 0)
     |> num_to_bool()
 
-    y = get_config_value(:float, "hardware_params", "movement_home_at_boot_y") || 0
+    y = (get_config_value(:float, "hardware_params", "movement_home_at_boot_y") || 0)
     |> num_to_bool()
 
-    z = get_config_value(:float, "hardware_params", "movement_home_at_boot_z") || 0
+    z = (get_config_value(:float, "hardware_params", "movement_home_at_boot_z") || 0)
     |> num_to_bool()
 
     %{

--- a/lib/farmbot/system/updates/updates.ex
+++ b/lib/farmbot/system/updates/updates.ex
@@ -268,7 +268,7 @@ defmodule Farmbot.System.Updates do
 
   @doc "Apply an OS (fwup) firmware."
   def apply_firmware(is_beta?, file_path, reboot) when is_boolean(is_beta?) do
-    Logger.busy 1, "Applying #{@target} OS update"
+    Logger.busy 1, "Applying #{@target} OS update (beta=#{is_beta?})"
     before_update()
     case @update_handler.apply_firmware(file_path) do
       :ok ->

--- a/lib/farmbot/system/updates/updates.ex
+++ b/lib/farmbot/system/updates/updates.ex
@@ -45,7 +45,7 @@ defmodule Farmbot.System.Updates do
       :token,
       :beta_opt_in,
       :os_update_server_overwrite,
-      :currently_on_beta
+      :currently_on_beta,
       :env,
       :commit,
       :target,
@@ -57,7 +57,7 @@ defmodule Farmbot.System.Updates do
       os_update_server_overwrite = get_config_value(:string, "settings", "os_update_server_overwrite")
       beta_opt_in? = is_binary(os_update_server_overwrite) || get_config_value(:bool, "settings", "beta_opt_in")
       token_bin = get_config_value(:string, "authorization", "token")
-      currently_on_beta? get_config_value(:bool, "settings", "currently_on_beta")
+      currently_on_beta? = get_config_value(:bool, "settings", "currently_on_beta")
       token = if token_bin, do: Farmbot.Jwt.decode!(token_bin), else: nil
       opts = %{
         token: token,

--- a/platform/host/bootstrap/fake_router.ex
+++ b/platform/host/bootstrap/fake_router.ex
@@ -22,7 +22,61 @@ defmodule Farmbot.Target.Bootstrap.Configurator.Router do
   @ssids File.read!("data.txt") |> Base.decode64!() |> :erlang.binary_to_term |> ScanResult.decode() |> ScanResult.sort_results() |> ScanResult.decode_security()
 
   get "/network" do
-    interfaces = [:eth0, :wlan0]
+    interfaces = %{
+      "eth0" => %{
+        ifname: "eth0",
+        index: 3,
+        is_broadcast: true,
+        is_lower_up: true,
+        is_multicast: true,
+        is_running: true,
+        is_up: true,
+        mac_address: "b8:27:eb:08:36:cc",
+        mac_broadcast: "ff:ff:ff:ff:ff:ff",
+        mtu: 1500,
+        operstate: :up,
+        stats: %{
+          collisions: 0,
+          multicast: 0,
+          rx_bytes: 1612969,
+          rx_dropped: 0,
+          rx_errors: 0,
+          rx_packets: 3997,
+          tx_bytes: 955853,
+          tx_dropped: 0,
+          tx_errors: 0,
+          tx_packets: 3006
+        },
+        type: :ethernet
+      },
+      "wlan0" => %{
+        ifname: "wlan0",
+        index: 2,
+        is_broadcast: true,
+        is_lower_up: false,
+        is_multicast: true,
+        is_running: false,
+        is_up: false,
+        mac_address: "b8:27:eb:5d:63:99",
+        mac_broadcast: "ff:ff:ff:ff:ff:ff",
+        mtu: 1500,
+        operstate: :down,
+        stats: %{
+          collisions: 0,
+          multicast: 0,
+          rx_bytes: 0,
+          rx_dropped: 0,
+          rx_errors: 0,
+          rx_packets: 0,
+          tx_bytes: 0,
+          tx_dropped: 0,
+          tx_errors: 0,
+          tx_packets: 0
+        },
+        type: :ethernet
+      }
+    }
+
     render_page(conn, "network", [interfaces: interfaces, post_action: "select_interface"])
   end
 

--- a/platform/target/network/network.ex
+++ b/platform/target/network/network.ex
@@ -24,6 +24,10 @@ defmodule Farmbot.Target.Network do
         |> List.delete("usb0") # Delete unusable entries if they exist.
         |> List.delete("lo")
         |> List.delete("sit0")
+        |> Map.new(fn(interface) ->
+          {:ok, settings} = Nerves.NetworkInterface.status(interface)
+          {interface, settings}
+        end)
     end
   end
 

--- a/priv/config_storage/migrations/20180416165217_add_beta_state.exs
+++ b/priv/config_storage/migrations/20180416165217_add_beta_state.exs
@@ -1,8 +1,9 @@
 defmodule Farmbot.System.ConfigStorage.Migrations.AddBetaState do
   use Ecto.Migration
   import Farmbot.System.ConfigStorage.MigrationHelpers
+
   @default_currently_on_beta Application.get_env(:farmbot, :default_currently_on_beta)
-  @default_currently_on_beta || raise("Missing application env config: `:default_currently_on_beta`")
+  if is_nil(@default_currently_on_beta), do: raise("Missing application env config: `:default_currently_on_beta`")
 
   def change do
     create_settings_config("currently_on_beta", :bool, @default_currently_on_beta)

--- a/priv/config_storage/migrations/20180416165217_add_beta_state.exs
+++ b/priv/config_storage/migrations/20180416165217_add_beta_state.exs
@@ -1,8 +1,10 @@
 defmodule Farmbot.System.ConfigStorage.Migrations.AddBetaState do
   use Ecto.Migration
   import Farmbot.System.ConfigStorage.MigrationHelpers
+  @default_currently_on_beta Application.get_env(:farmbot, :default_currently_on_beta)
+  @default_currently_on_beta || raise("Missing application env config: `:default_currently_on_beta`")
 
   def change do
-    create_settings_config("currently_on_beta", :bool, false)
+    create_settings_config("currently_on_beta", :bool, @default_currently_on_beta)
   end
 end

--- a/priv/static/styles.css
+++ b/priv/static/styles.css
@@ -21,6 +21,11 @@ h1, h2 {
   margin-top: 3rem;
 }
 
+.no-pad {
+  margin: 0;
+  padding: 0;
+}
+
 .gray {
   display: inline-block;
   cursor: pointer;
@@ -163,22 +168,23 @@ input[type="radio"]:checked:after {
 
 .connection-type {
   display: inline-block;
-  padding: 1rem;
+  padding: 0.5rem;
   cursor: pointer;
+  width: 9rem;
 }
 
 .connection-type-box {
   background: white;
   border: 2px solid #434343;
   border-radius: 0.5rem;
-  width: 10rem;
-  height: 10rem;
+  width: 9rem;
+  height: 9rem;
   text-align: center;
 }
 
 .connection-type-box > img {
-  width: 8rem;
-  height: 8rem;
+  width: 7rem;
+  height: 7rem;
 }
 
 .connection-type-box > span {
@@ -188,6 +194,50 @@ input[type="radio"]:checked:after {
 
 .connection-type-box:hover {
   background: #ccc;
+}
+
+.connection-type-info {
+  margin-top: 0.25rem;
+  float: left;
+  border: 1px solid #ccc;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  text-transform: none;
+  font-weight: bold;
+  font-style: italic;
+  font-size: 0.9rem;
+  color: #ccc;
+}
+
+.connection-type-info-content {
+  padding-top: 0.25rem;
+  opacity: 0;
+  overflow: hidden;
+  text-transform: none;
+  font-weight: normal;
+  margin: 0;
+  font-size: 0.6rem;
+  transition: all 0.5s ease;
+}
+
+.connection-type-info-content p {
+  font-size: 0.75rem;
+}
+
+.connection-type-info-content h4 {
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.connection-type-info:hover {
+  border-color: #434343;
+  color: #434343;
+}
+
+.connection-type-info:hover + .connection-type-info-content {
+  transition: all 0.5s ease 0.2s;
+  opacity: 1;
 }
 
 input:checked + .connection-type-box {

--- a/priv/static/templates/network.html.eex
+++ b/priv/static/templates/network.html.eex
@@ -28,14 +28,23 @@
           <p>How will you connect FarmBot to the Internet?</p>
           <input id="interface" name="interface" value="" hidden/>
           <% # Main form stuff %>
-          <%= for ifname <- interfaces do %>
+          <%= for {ifname, settings} <- interfaces do %>
             <label class="connection-type" for='<%= ifname %>'>
               <input type="radio" id='<%= ifname %>' name="interfaceRadio" value=""/>
               <div class="connection-type-box">
                 <img src='<%= if String.contains?(to_string(ifname), "w"), do: "icon_wifi.svg", else: "icon_ethernet.svg"%>'/>
-                <span><%= if String.contains?(to_string(ifname), "w"), do: "WiFi", else: "Ethernet"%> (<%= ifname %>)</span>
+                <span><%= if String.contains?(to_string(ifname), "w"), do: "WiFi", else: "Ethernet"%></span>
               </div>
+
             </label>
+
+            <div class="advanced">
+              <h4> Interface name </h4>
+              <span> <%= ifname %> </span>
+
+              <h4> Interface mac address </h4>
+              <span> <%= settings.mac_address %> </span>
+            </div>
           <% end %>
 
           <% #/Main form stuff %>

--- a/priv/static/templates/network.html.eex
+++ b/priv/static/templates/network.html.eex
@@ -29,26 +29,22 @@
           <input id="interface" name="interface" value="" hidden/>
           <% # Main form stuff %>
           <%= for {ifname, settings} <- interfaces do %>
-            <label class="connection-type" for='<%= ifname %>'>
+            <label class="connection-type no-pad" for='<%= ifname %>'>
               <input type="radio" id='<%= ifname %>' name="interfaceRadio" value=""/>
               <div class="connection-type-box">
                 <img src='<%= if String.contains?(to_string(ifname), "w"), do: "icon_wifi.svg", else: "icon_ethernet.svg"%>'/>
                 <span><%= if String.contains?(to_string(ifname), "w"), do: "WiFi", else: "Ethernet"%></span>
               </div>
 
+              <div class="connection-type-info">i</div>
+              <div class="connection-type-info-content">
+                <h4> <%= ifname %> mac address: </h4> <p><%= settings.mac_address %></p>
+              </div>
             </label>
-
-            <div class="advanced">
-              <h4> Interface name </h4>
-              <span> <%= ifname %> </span>
-
-              <h4> Interface mac address </h4>
-              <span> <%= settings.mac_address %> </span>
-            </div>
           <% end %>
 
           <% #/Main form stuff %>
-          <div class="button"> <input type=submit value="next" onclick="select_interface()"> </div>
+          <div class="button no-pad"> <input type=submit value="next" onclick="select_interface()"> </div>
         </form>
       </div>
     </div>

--- a/test/farmbot/system/updates/updates_test.exs
+++ b/test/farmbot/system/updates/updates_test.exs
@@ -84,6 +84,7 @@ defmodule Farmbot.System.UpdatesTest do
         beta_os_update_server: @beta_os_update_server,
       },
       beta_opt_in: false,
+      currently_on_beta: false,
       os_update_server_overwrite: nil,
       env: :prod,
       commit: @commit,


### PR DESCRIPTION
* Beta updates should _always_ try to flash firmware.
* Bump Nerves and friends to 1.0.0.
* Add new firmware params: `movement_invert_2_endpoints_<x|y|z>`.
* Add new rpc: `set_pin_io_mode`.
* Clean up positions in logs.
* Update Configurator to support more control over network setup.
* Add mdns to development setups.
* Remove use of `iw`.
* Add checks for uart auto detector.
* Syncing a sequence reindexes running regimens that require it.