### PR TITLE
Act on Credo warnings

### DIFF
--- a/lib/farmbot/firmware/uart_handler/framing.ex
+++ b/lib/farmbot/firmware/uart_handler/framing.ex
@@ -102,23 +102,58 @@ defmodule Farmbot.Firmware.UartHandler.Framing do
   end
 
   # Handle not enough data case
-  defp process_data(_separator, sep_length, _max_length, processed, to_process, lines, _log_input)
+  defp process_data(
+         _separator,
+         sep_length,
+         _max_length,
+         processed,
+         to_process,
+         lines,
+         _log_input
+       )
        when byte_size(to_process) < sep_length do
     {processed, to_process, lines}
   end
 
   # Process data until separator or next char
-  defp process_data(separator, sep_length, max_length, processed, to_process, lines, log_input) do
+  defp process_data(
+         separator,
+         sep_length,
+         max_length,
+         processed,
+         to_process,
+         lines,
+         log_input
+       ) do
     case to_process do
       # Handle separater
       <<^separator::binary-size(sep_length), rest::binary>> ->
         new_lines = lines ++ [do_parse_code(processed, log_input)]
-        process_data(separator, sep_length, max_length, <<>>, rest, new_lines, log_input)
+
+        process_data(
+          separator,
+          sep_length,
+          max_length,
+          <<>>,
+          rest,
+          new_lines,
+          log_input
+        )
 
       # Handle line too long case
-      to_process when byte_size(processed) == max_length and to_process != <<>> ->
+      to_process
+      when byte_size(processed) == max_length && to_process != <<>> ->
         new_lines = lines ++ [{:partial, processed}]
-        process_data(separator, sep_length, max_length, <<>>, to_process, new_lines, log_input)
+
+        process_data(
+          separator,
+          sep_length,
+          max_length,
+          <<>>,
+          to_process,
+          new_lines,
+          log_input
+        )
 
       # Handle next char
       <<next_char::binary-size(1), rest::binary>> ->

--- a/lib/farmbot/firmware/uart_handler/framing.ex
+++ b/lib/farmbot/firmware/uart_handler/framing.ex
@@ -40,17 +40,29 @@ defmodule Farmbot.Firmware.UartHandler.Framing do
   def init(args) do
     max_length = Keyword.get(args, :max_length, 4096)
     separator = Keyword.get(args, :separator, "\n")
-    log_input = Farmbot.System.ConfigStorage.get_config_value(:bool, "settings", "firmware_input_log")
-    log_output = Farmbot.System.ConfigStorage.get_config_value(:bool, "settings", "firmware_output_log")
-    state = %State{max_length: max_length, separator: separator, log_input: log_input, log_output: log_output}
+
+    log_input =
+      Farmbot.System.ConfigStorage.get_config_value(:bool, "settings", "firmware_input_log")
+
+    log_output =
+      Farmbot.System.ConfigStorage.get_config_value(:bool, "settings", "firmware_output_log")
+
+    state = %State{
+      max_length: max_length,
+      separator: separator,
+      log_input: log_input,
+      log_output: log_output
+    }
+
     {:ok, state}
   end
 
   def add_framing(data, state) do
     # maybe log output here
     if state.log_output do
-      Logger.debug 3, data
+      Logger.debug(3, data)
     end
+
     {:ok, data <> state.separator, state}
   end
 
@@ -110,19 +122,27 @@ defmodule Farmbot.Firmware.UartHandler.Framing do
 
       # Handle next char
       <<next_char::binary-size(1), rest::binary>> ->
-        process_data(separator, sep_length, max_length, processed <> next_char, rest, lines, log_input)
+        process_data(
+          separator,
+          sep_length,
+          max_length,
+          processed <> next_char,
+          rest,
+          lines,
+          log_input
+        )
     end
   end
 
   defp do_parse_code(processed, log_input) do
     if log_input do
-      Logger.debug 3, processed
+      Logger.debug(3, processed)
     end
 
     parse_code(processed)
   rescue
     er ->
-      Logger.error 1, "Firmware parser error: #{Exception.message(er)}"
+      Logger.error(1, "Firmware parser error: #{Exception.message(er)}")
       {nil, :noop}
   end
 end


### PR DESCRIPTION
@ConnorRigby I ran the `formatter` and `credo` on this file. I'm not really sure if it helps readability... I don't like args that span through multiple lines. At least, we can use this as a discussion point until we find out an optimal solution here.

What do you suggest here? I like that the args are not "short", like `max_len` but that's a strategy we could use.