### PR TITLE
Fix typo preventing custom dns rules from working.

### DIFF
--- a/lib/farmbot/system/config_storage/network_interface.ex
+++ b/lib/farmbot/system/config_storage/network_interface.ex
@@ -24,6 +24,7 @@ defmodule Farmbot.System.ConfigStorage.NetworkInterface do
     field(:ipv4_gateway, :string)
     field(:ipv4_subnet_mask, :string)
     field(:domain, :string)
+    # This is a typo. It should be `nameservers`
     field(:name_servers, :string)
 
     field(:regulatory_domain, :string, default: "US")

--- a/platform/target/network/network.ex
+++ b/platform/target/network/network.ex
@@ -182,9 +182,12 @@ defmodule Farmbot.Target.Network do
     |> maybe_use_domain(config)
   end
 
+  # This is a typo. It should have been `nameservers` not `name_servers`
+  # It is however stored in the database as
+  # `name_servers`, so it can not be changed without a migration.
   defp maybe_use_name_servers(opts, config) do
     if config.name_servers do
-      Keyword.put(opts, :name_servers, String.split(config.name_servers, " "))
+      Keyword.put(opts, :nameservers, String.split(config.name_servers, " "))
     else
       opts
     end


### PR DESCRIPTION
Nerves.Network uses `nameservers`, but FarmBot code
uses `name_servers`. This is a typo, and could be
fixed by a database migration in the future.