### PR TITLE
Mox boilerplate

### DIFF
--- a/farmbot_ext/config/config.exs
+++ b/farmbot_ext/config/config.exs
@@ -4,6 +4,12 @@ config :logger, handle_otp_reports: true, handle_sasl_reports: true
 config :farmbot_celery_script, FarmbotCeleryScript.SysCalls,
   sys_calls: FarmbotCeleryScript.SysCalls.Stubs
 
+if Mix.env() == :test do
+  config :farmbot_ext, FarmbotExt.API.Preloader, preloader_impl: MockPreloader
+else
+  config :farmbot_ext, FarmbotExt.API.Preloader, preloader_impl: FarmbotExt.API.Preloader.HTTP
+end
+
 import_config "ecto.exs"
 import_config "farmbot_core.exs"
 import_config "lagger.exs"

--- a/farmbot_ext/lib/farmbot_ext/amqp/auto_sync_channel.ex
+++ b/farmbot_ext/lib/farmbot_ext/amqp/auto_sync_channel.ex
@@ -50,14 +50,15 @@ defmodule FarmbotExt.AMQP.AutoSyncChannel do
   alias __MODULE__, as: State
 
   @doc false
-  def start_link(args) do
-    GenServer.start_link(__MODULE__, args, name: __MODULE__)
+  def start_link(args, opts \\ [name: __MODULE__]) do
+    GenServer.start_link(__MODULE__, args, opts)
   end
 
   def init(args) do
     Process.flag(:sensitive, true)
     jwt = Keyword.fetch!(args, :jwt)
-    {:ok, %State{conn: nil, chan: nil, jwt: jwt, preloaded: false}, 1000}
+    timeout = Keyword.get(args, :timeout, 1000)
+    {:ok, %State{conn: nil, chan: nil, jwt: jwt, preloaded: false}, timeout}
   end
 
   def terminate(reason, state) do

--- a/farmbot_ext/lib/farmbot_ext/api/preloader.ex
+++ b/farmbot_ext/lib/farmbot_ext/api/preloader.ex
@@ -5,6 +5,15 @@ defmodule FarmbotExt.API.Preloader do
     * FarmbotCore.Asset.FbosConfig
     * FarmbotCore.Asset.FirmwareConfig
   """
+  Application.get_env(:farmbot_ext, __MODULE__)[:preloader_impl] ||
+    Mix.raise("""
+    No default preloader implementation was provided. 
+
+      config :farmbot_ext, FarmbotExt.API.Preloader, [
+        preloader_impl: FarmbotExt.API.Preloader.HTTP
+      ]
+    """)
+
   @callback preload_all :: :ok | :error
 
   def preload_all do

--- a/farmbot_ext/lib/farmbot_ext/api/preloader.ex
+++ b/farmbot_ext/lib/farmbot_ext/api/preloader.ex
@@ -5,69 +5,9 @@ defmodule FarmbotExt.API.Preloader do
     * FarmbotCore.Asset.FbosConfig
     * FarmbotCore.Asset.FirmwareConfig
   """
-  alias Ecto.{Changeset, Multi}
+  @callback preload_all :: :ok | :error
 
-  require FarmbotCore.Logger
-  alias FarmbotExt.API
-  alias API.{Reconciler, SyncGroup, EagerLoader}
-
-  alias FarmbotCore.{
-    Asset,
-    Asset.Repo,
-    Asset.Sync
-  }
-
-  @doc """
-  Syncronous call to sync or preload assets.
-  Starts with `group_0` to check if `auto_sync` is enabled. If it is, 
-  actually sync all resources. If it is not, preload all resources.
-  """
-  def preload_all() do
-    sync_changeset = API.get_changeset(Sync)
-    sync = Changeset.apply_changes(sync_changeset)
-
-    multi = Multi.new()
-
-    with {:ok, multi} <- Reconciler.sync_group(multi, sync, SyncGroup.group_0()),
-         {:ok, _} <- Repo.transaction(multi) do
-      auto_sync_change =
-        Enum.find_value(multi.operations, fn {{key, _id}, {:changeset, change, []}} ->
-          key == :fbos_configs && Changeset.get_change(change, :auto_sync)
-        end)
-
-      FarmbotCore.Logger.success(3, "Successfully synced bootup resources.")
-
-      :ok = maybe_auto_sync(sync_changeset, auto_sync_change || Asset.fbos_config().auto_sync)
-    end
-  end
-
-  # When auto_sync is enabled, do the full sync.
-  defp maybe_auto_sync(sync_changeset, true) do
-    FarmbotCore.Logger.busy(3, "bootup auto sync")
-    sync = Changeset.apply_changes(sync_changeset)
-    multi = Multi.new()
-
-    with {:ok, multi} <- Reconciler.sync_group(multi, sync, SyncGroup.group_1()),
-         {:ok, multi} <- Reconciler.sync_group(multi, sync, SyncGroup.group_2()),
-         {:ok, multi} <- Reconciler.sync_group(multi, sync, SyncGroup.group_3()),
-         {:ok, multi} <- Reconciler.sync_group(multi, sync, SyncGroup.group_4()) do
-      Multi.insert(multi, :syncs, sync_changeset)
-      |> Repo.transaction()
-
-      FarmbotCore.Logger.success(3, "bootup auto sync complete")
-    else
-      error -> FarmbotCore.Logger.error(3, "bootup auto sync failed #{inspect(error)}")
-    end
-
-    :ok
-  end
-
-  # When auto_sync is disabled preload the sync.
-  defp maybe_auto_sync(sync_changeset, false) do
-    FarmbotCore.Logger.busy(3, "preloading sync")
-    sync = Changeset.apply_changes(sync_changeset)
-    EagerLoader.preload(sync)
-    FarmbotCore.Logger.success(3, "preloaded sync ok")
-    :ok
+  def preload_all do
+    Application.get_env(:farmbot_ext, __MODULE__)[:preloader_impl].preload_all()
   end
 end

--- a/farmbot_ext/lib/farmbot_ext/api/preloader/http_preloader.ex
+++ b/farmbot_ext/lib/farmbot_ext/api/preloader/http_preloader.ex
@@ -1,0 +1,69 @@
+defmodule FarmbotExt.API.Preloader.HTTP do
+  alias Ecto.{Changeset, Multi}
+
+  require FarmbotCore.Logger
+  alias FarmbotExt.API
+  alias API.{Reconciler, SyncGroup, EagerLoader}
+
+  alias FarmbotCore.{
+    Asset,
+    Asset.Repo,
+    Asset.Sync
+  }
+
+  @behaviour FarmbotExt.API.Preloader
+
+  @doc """
+  Syncronous call to sync or preload assets.
+  Starts with `group_0` to check if `auto_sync` is enabled. If it is, 
+  actually sync all resources. If it is not, preload all resources.
+  """
+  def preload_all() do
+    sync_changeset = API.get_changeset(Sync)
+    sync = Changeset.apply_changes(sync_changeset)
+
+    multi = Multi.new()
+
+    with {:ok, multi} <- Reconciler.sync_group(multi, sync, SyncGroup.group_0()),
+         {:ok, _} <- Repo.transaction(multi) do
+      auto_sync_change =
+        Enum.find_value(multi.operations, fn {{key, _id}, {:changeset, change, []}} ->
+          key == :fbos_configs && Changeset.get_change(change, :auto_sync)
+        end)
+
+      FarmbotCore.Logger.success(3, "Successfully synced bootup resources.")
+
+      :ok = maybe_auto_sync(sync_changeset, auto_sync_change || Asset.fbos_config().auto_sync)
+    end
+  end
+
+  # When auto_sync is enabled, do the full sync.
+  defp maybe_auto_sync(sync_changeset, true) do
+    FarmbotCore.Logger.busy(3, "bootup auto sync")
+    sync = Changeset.apply_changes(sync_changeset)
+    multi = Multi.new()
+
+    with {:ok, multi} <- Reconciler.sync_group(multi, sync, SyncGroup.group_1()),
+         {:ok, multi} <- Reconciler.sync_group(multi, sync, SyncGroup.group_2()),
+         {:ok, multi} <- Reconciler.sync_group(multi, sync, SyncGroup.group_3()),
+         {:ok, multi} <- Reconciler.sync_group(multi, sync, SyncGroup.group_4()) do
+      Multi.insert(multi, :syncs, sync_changeset)
+      |> Repo.transaction()
+
+      FarmbotCore.Logger.success(3, "bootup auto sync complete")
+    else
+      error -> FarmbotCore.Logger.error(3, "bootup auto sync failed #{inspect(error)}")
+    end
+
+    :ok
+  end
+
+  # When auto_sync is disabled preload the sync.
+  defp maybe_auto_sync(sync_changeset, false) do
+    FarmbotCore.Logger.busy(3, "preloading sync")
+    sync = Changeset.apply_changes(sync_changeset)
+    EagerLoader.preload(sync)
+    FarmbotCore.Logger.success(3, "preloaded sync ok")
+    :ok
+  end
+end

--- a/farmbot_ext/mix.exs
+++ b/farmbot_ext/mix.exs
@@ -30,6 +30,7 @@ defmodule FarmbotExt.MixProject do
       {:hackney, "~> 1.14"},
       {:uuid, "~> 1.1"},
       {:amqp, "1.1.1"},
+      {:mox, "~> 0.5", only: :test},
       {:excoveralls, "~> 0.10", only: [:test], targets: [:host]},
       {:dialyxir, "~> 1.0.0-rc.3", only: [:dev], targets: [:host], runtime: false},
       {:ex_doc, "~> 0.19", only: [:dev], targets: [:host], runtime: false}

--- a/farmbot_ext/mix.exs
+++ b/farmbot_ext/mix.exs
@@ -10,6 +10,13 @@ defmodule FarmbotExt.MixProject do
       elixir: @elixir_version,
       start_permanent: Mix.env() == :prod,
       elixirc_paths: ["lib", "vendor"],
+      test_coverage: [tool: ExCoveralls],
+      preferred_cli_env: [
+        coveralls: :test,
+        "coveralls.detail": :test,
+        "coveralls.post": :test,
+        "coveralls.html": :test
+      ],
       deps: deps()
     ]
   end

--- a/farmbot_ext/mix.lock
+++ b/farmbot_ext/mix.lock
@@ -27,6 +27,7 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mime": {:hex, :mime, "1.3.1", "30ce04ab3175b6ad0bdce0035cba77bba68b813d523d1aac73d9781b4d193cf8", [:mix], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm"},
+  "mox": {:hex, :mox, "0.5.0", "c519b48407017a85f03407a9a4c4ceb7cc6dec5fe886b2241869fb2f08476f9e", [:mix], [], "hexpm"},
   "muontrap": {:hex, :muontrap, "0.4.1", "4d12af9d1a8f45037cf6d602b614bdc1e1781d110b0fef5df4c3a0aaec76dfae", [:make, :mix], [{:elixir_make, "~> 0.5", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},

--- a/farmbot_ext/test/dummy_test.exs
+++ b/farmbot_ext/test/dummy_test.exs
@@ -1,7 +1,0 @@
-defmodule FarmbotExt.DummyTest do
-  use ExUnit.Case
-
-  test "this is a hack lol" do
-    assert 1 == 1
-  end
-end

--- a/farmbot_ext/test/farmbot_ext/amqp/auto_sync_channel_test.exs
+++ b/farmbot_ext/test/farmbot_ext/amqp/auto_sync_channel_test.exs
@@ -1,0 +1,44 @@
+defmodule FarmbotExt.AMQP.AutoSyncChannelTest do
+  use ExUnit.Case
+  import Mox
+  alias FarmbotExt.JWT
+
+  @fake_jwt "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhZ" <>
+              "G1pbkBhZG1pbi5jb20iLCJpYXQiOjE1MDIxMjcxMTcsImp0a" <>
+              "SI6IjlhZjY2NzJmLTY5NmEtNDhlMy04ODVkLWJiZjEyZDlhY" <>
+              "ThjMiIsImlzcyI6Ii8vbG9jYWxob3N0OjMwMDAiLCJleHAiO" <>
+              "jE1MDU1ODMxMTcsIm1xdHQiOiJsb2NhbGhvc3QiLCJvc191c" <>
+              "GRhdGVfc2VydmVyIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvb" <>
+              "S9yZXBvcy9mYXJtYm90L2Zhcm1ib3Rfb3MvcmVsZWFzZXMvb" <>
+              "GF0ZXN0IiwiZndfdXBkYXRlX3NlcnZlciI6Imh0dHBzOi8vY" <>
+              "XBpLmdpdGh1Yi5jb20vcmVwb3MvRmFybUJvdC9mYXJtYm90L" <>
+              "WFyZHVpbm8tZmlybXdhcmUvcmVsZWFzZXMvbGF0ZXN0IiwiY" <>
+              "m90IjoiZGV2aWNlXzE1In0.XidSeTKp01ngtkHzKD_zklMVr" <>
+              "9ZUHX-U_VDlwCSmNA8ahOHxkwCtx8a3o_McBWvOYZN8RRzQV" <>
+              "LlHJugHq1Vvw2KiUktK_1ABQ4-RuwxOyOBqqc11-6H_GbkM8" <>
+              "dyzqRaWDnpTqHzkHGxanoWVTTgGx2i_MZLr8FPZ8prnRdwC1" <>
+              "x9zZ6xY7BtMPtHW0ddvMtXU8ZVF4CWJwKSaM0Q2pTxI9GRqr" <>
+              "p5Y8UjaKufif7bBPOUbkEHLNOiaux4MQr-OWAC8TrYMyFHzt" <>
+              "eXTEVkqw7rved84ogw6EKBSFCVqwRA-NKWLpPMV_q7fRwiEG" <>
+              "Wj7R-KZqRweALXuvCLF765E6-ENxA"
+
+  setup do
+    jwt = JWT.decode!(@fake_jwt)
+    %{jwt: jwt}
+  end
+
+  test "handles timeouts", %{jwt: jwt} do
+    timeout = 1
+    wait = timeout + 10
+    test_pid = self()
+
+    expect(MockPreloader, :preload_all, fn ->
+      send(test_pid, :ding!)
+      :ok
+    end)
+
+    {:ok, pid} = FarmbotExt.AMQP.AutoSyncChannel.start_link(jwt: jwt, timeout: timeout)
+    allow(MockPreloader, test_pid, pid)
+    assert_receive :ding!, wait
+  end
+end

--- a/farmbot_ext/test/preloader_test.exs
+++ b/farmbot_ext/test/preloader_test.exs
@@ -1,0 +1,13 @@
+defmodule FarmbotExt.API.PreloaderTest do
+  use ExUnit.Case
+  import Mox
+
+  # Make sure mocks are verified when the test exits
+  setup :verify_on_exit!
+
+  test "preload" do
+    expect(MockPreloader, :preload_all, fn -> :ok end)
+
+    assert FarmbotExt.API.Preloader.preload_all() == :ok
+  end
+end

--- a/farmbot_ext/test/test_helper.exs
+++ b/farmbot_ext/test/test_helper.exs
@@ -1,2 +1,3 @@
 Mox.defmock(MockPreloader, for: FarmbotExt.API.Preloader)
+
 ExUnit.start()

--- a/farmbot_ext/test/test_helper.exs
+++ b/farmbot_ext/test/test_helper.exs
@@ -1,1 +1,2 @@
+Mox.defmock(MockPreloader, for: FarmbotExt.API.Preloader)
 ExUnit.start()


### PR DESCRIPTION
# What's New?

 * `farmbot_ext` coverage up to 6.1%
 * Break out hardcoded configs such as `name:` and `timeout:` into configurable keys to make testing easier.
 * Add `mox` and `excoveralls` to test suite.

# What's Next?

 * More unit tests for `farmbot_ext`