### PR TITLE
Fix execution of regimens

### DIFF
--- a/farmbot_core/lib/farmbot_core/asset_workers/farm_event_worker.ex
+++ b/farmbot_core/lib/farmbot_core/asset_workers/farm_event_worker.ex
@@ -63,6 +63,10 @@ defimpl FarmbotCore.AssetWorker, for: FarmbotCore.Asset.FarmEvent do
     end
   end
 
+  defp init_event_completed(%{farm_event: %{executable_type: "Regimen"}} = state, _) do
+    {:ok, state, 0}
+  end
+
   defp init_event_completed(_, _) do
     Logger.warn("No future events")
     :ignore
@@ -73,7 +77,6 @@ defimpl FarmbotCore.AssetWorker, for: FarmbotCore.Asset.FarmEvent do
   end
 
   def handle_info(:timeout, %State{} = state) do
-    Logger.info("build_calendar")
     next = FarmEvent.build_calendar(state.farm_event, state.datetime)
 
     if next do


### PR DESCRIPTION
* The API stores regimen farm_events with a time of midnight on the creation date.
  The FarmEvent Runner saw this as an event that was too old.

* The Regimen worker was exeuting _any_ item
  that was in the future, rather than an item that was within about 2 minutes