### PR TITLE
Implement error handling for api 429 errors

### DIFF
--- a/farmbot_core/lib/farmbot_core/asset_workers/regimen_instance_worker.ex
+++ b/farmbot_core/lib/farmbot_core/asset_workers/regimen_instance_worker.ex
@@ -30,6 +30,7 @@ defimpl FarmbotCore.AssetWorker, for: FarmbotCore.Asset.RegimenInstance do
   end
 
   def init([regimen_instance, args]) do
+    Logger.warn "RegimenInstance #{inspect(regimen_instance)} initializing"
     apply_sequence = Keyword.get(args, :apply_sequence, &apply_sequence/2)
     unless is_function(apply_sequence, 2) do
       raise "RegimenInstance Sequence handler should be a 2 arity function"

--- a/farmbot_ext/lib/farmbot_ext/api/eager_loader.ex
+++ b/farmbot_ext/lib/farmbot_ext/api/eager_loader.ex
@@ -30,7 +30,8 @@ defmodule FarmbotExt.API.EagerLoader do
 
   def preload(asset_module, %{id: id}) when is_atom(asset_module) do
     local = Repo.one(from(m in asset_module, where: m.id == ^id)) || asset_module
-    :ok = API.get_changeset(local, id) |> cache()
+    {:ok, changeset} = API.get_changeset(local, id)
+    :ok = cache(changeset)
   end
 
   @doc "Get a Changeset by module and id. May return nil"

--- a/farmbot_ext/lib/farmbot_ext/api/preloader.ex
+++ b/farmbot_ext/lib/farmbot_ext/api/preloader.ex
@@ -25,12 +25,10 @@ defmodule FarmbotExt.API.Preloader do
   """
   @callback preload_all :: :ok | :error
   def preload_all() do
-    sync_changeset = API.get_changeset(Sync)
-    sync = Changeset.apply_changes(sync_changeset)
-
-    multi = Multi.new()
-
-    with {:ok, multi} <- Reconciler.sync_group(multi, sync, SyncGroup.group_0()),
+    with {:ok, sync_changeset} <- API.get_changeset(Sync),
+         sync <- Changeset.apply_changes(sync_changeset),
+         multi <- Multi.new(),
+         {:ok, multi} <- Reconciler.sync_group(multi, sync, SyncGroup.group_0()),
          {:ok, _} <- Repo.transaction(multi) do
       auto_sync_change =
         Enum.find_value(multi.operations, fn {{key, _id}, {:changeset, change, []}} ->

--- a/farmbot_ext/lib/farmbot_ext/api/preloader/http.ex
+++ b/farmbot_ext/lib/farmbot_ext/api/preloader/http.ex
@@ -19,12 +19,10 @@ defmodule FarmbotExt.API.Preloader.HTTP do
   actually sync all resources. If it is not, preload all resources.
   """
   def preload_all() do
-    sync_changeset = API.get_changeset(Sync)
-    sync = Changeset.apply_changes(sync_changeset)
-
-    multi = Multi.new()
-
-    with {:ok, multi} <- Reconciler.sync_group(multi, sync, SyncGroup.group_0()),
+    with {:ok, sync_changeset} <- API.get_changeset(Sync),
+         sync <- Changeset.apply_changes(sync_changeset),
+         multi <- Multi.new(),
+         {:ok, multi} <- Reconciler.sync_group(multi, sync, SyncGroup.group_0()),
          {:ok, _} <- Repo.transaction(multi) do
       auto_sync_change =
         Enum.find_value(multi.operations, fn {{key, _id}, {:changeset, change, []}} ->

--- a/farmbot_os/lib/farmbot_os/sys_calls.ex
+++ b/farmbot_os/lib/farmbot_os/sys_calls.ex
@@ -248,13 +248,12 @@ defmodule FarmbotOS.SysCalls do
 
   def sync() do
     FarmbotCore.Logger.busy(3, "Syncing")
-    sync_changeset = API.get_changeset(Sync)
-    sync = Changeset.apply_changes(sync_changeset)
-    multi = Multi.new()
 
-    :ok = BotState.set_sync_status("syncing")
-
-    with {:ok, multi} <- Reconciler.sync_group(multi, sync, SyncGroup.group_0()),
+    with {:ok, sync_changeset} <- API.get_changeset(Sync),
+         sync <- Changeset.apply_changes(sync_changeset),
+         multi <- Multi.new(),
+         :ok <- BotState.set_sync_status("syncing"),
+         {:ok, multi} <- Reconciler.sync_group(multi, sync, SyncGroup.group_0()),
          {:ok, multi} <- Reconciler.sync_group(multi, sync, SyncGroup.group_1()),
          {:ok, multi} <- Reconciler.sync_group(multi, sync, SyncGroup.group_2()),
          {:ok, multi} <- Reconciler.sync_group(multi, sync, SyncGroup.group_3()),


### PR DESCRIPTION
* Changes auto_sync_channel to no longer use `handle_continue`
  * If preloading fails, retry instead of crashing.
* Make `get_changeset` return an error rather than raising an exception
  * Update every use of that function to handle posibility of error