### PR TITLE
Further refactor Preloader to allow for error recovery

### DIFF
--- a/farmbot_ext/lib/farmbot_ext/amqp/auto_sync_channel.ex
+++ b/farmbot_ext/lib/farmbot_ext/amqp/auto_sync_channel.ex
@@ -57,7 +57,7 @@ defmodule FarmbotExt.AMQP.AutoSyncChannel do
     else
       {:error, reason} ->
         BotState.set_sync_status("sync_error")
-        Logger.error("Error preloading. #{reason}")
+        FarmbotCore.Logger.error(1, "Error preloading. #{inspect(reason)}")
         Process.send_after(self(), :preload, 5000)
         {:noreply, state}
     end


### PR DESCRIPTION
Previous system would crash the calling processes with a `MatchError`
instead of returning an error. The end result after this commit is
still the same - the auto_sync channel will attempt a resync
every 5 seconds. The log messages/user experience should just
be better now.