### PR TITLE
Handle unknown auto_sync messages

### DIFF
--- a/farmbot_ext/lib/farmbot_ext/amqp/auto_sync_channel.ex
+++ b/farmbot_ext/lib/farmbot_ext/amqp/auto_sync_channel.ex
@@ -15,7 +15,28 @@ defmodule FarmbotExt.AMQP.AutoSyncChannel do
   require Logger
   require FarmbotCore.Logger
 
-  @cache_kinds ~w(
+  # The API dispatches messages for other resources, but these
+  # are the only ones that Farmbot needs to sync.
+  @known_kinds ~w(
+    Device
+    FarmEvent
+    FarmwareEnv
+    FarmwareInstallation
+    FbosConfig
+    FirmwareConfig
+    Peripheral
+    PinBinding
+    Point
+    Regimen
+    Sensor
+    Sequence
+    Tool
+  )
+
+  # Sync messgaes about these assets
+  # should not be cached. They need to be applied
+  # in real time.
+  @no_cache_kinds ~w(
     Device
     FbosConfig
     FirmwareConfig
@@ -93,9 +114,12 @@ defmodule FarmbotExt.AMQP.AutoSyncChannel do
     body = data["body"]
 
     case String.split(key, ".") do
-      ["bot", ^device, "sync", asset_kind, id_str] ->
+      ["bot", ^device, "sync", asset_kind, id_str] when asset_kind in @known_kinds ->
         id = data["id"] || String.to_integer(id_str)
         handle_asset(asset_kind, id, body)
+
+      ["bot", ^device, "sync", asset_kind, _id_str] ->
+        Logger.warn("Unknown syncable asset: #{asset_kind}")
 
       _ ->
         Logger.info("ignoring route: #{key}")
@@ -127,7 +151,7 @@ defmodule FarmbotExt.AMQP.AutoSyncChannel do
     end
   end
 
-  def cache_sync(kind, id, params) when kind in @cache_kinds do
+  def cache_sync(kind, id, params) when kind in @no_cache_kinds do
     :ok = BotState.set_sync_status("syncing")
     :ok = Asset.Command.update(kind, id, params)
     :ok = BotState.set_sync_status("synced")

--- a/farmbot_ext/test/farmbot_ext/amqp/auto_sync_channel_test.exs
+++ b/farmbot_ext/test/farmbot_ext/amqp/auto_sync_channel_test.exs
@@ -121,6 +121,22 @@ defmodule AutoSyncChannelTest do
     assert_receive {:rpc_reply_called, %{fake: :chan}, "device_15", "xyz"}
   end
 
+  test "wont autosync unknown assets" do
+    fake_con = %{fake: :conn}
+    fake_chan = %{fake: :chan}
+    fake_response = %{conn: fake_con, chan: fake_chan}
+
+    %{pid: pid} = pretend_network_returned(fake_response)
+
+    payload =
+      JSON.encode!(%{
+        args: %{label: "xyz"}
+      })
+
+    send(pid, {:basic_deliver, payload, %{routing_key: "bot.device_15.sync.SavedGarden.999"}})
+    assert_receive {:rpc_reply_called, %{fake: :chan}, "device_15", "xyz"}
+  end
+
   test "ignores asset deletion when auto_sync is off" do
     %{pid: pid} = under_normal_conditions()
     test_pid = self()
@@ -175,7 +191,7 @@ defmodule AutoSyncChannelTest do
     assert_receive {:update_called, ^module_name, 999, %{"foo" => "bar"}}
   end
 
-  test "handles auto_sync of 'cache_assets' when auto_sync is false" do
+  test "handles auto_sync of 'no_cache' when auto_sync is false" do
     test_pid = self()
     %{pid: pid} = under_normal_conditions()
 


### PR DESCRIPTION
Adds a blacklist of known asset types that FarmBot can
handle and sync/cache. This is important for when new assets are added or
assets are dispatched for the frontend to consume.