### PR TITLE
ENV configuration option for `assert_receive_timeout`

### DIFF
--- a/farmbot_ext/test/test_helper.exs
+++ b/farmbot_ext/test/test_helper.exs
@@ -5,5 +5,10 @@ Mox.defmock(FarmbotCore.Asset.Command, for: FarmbotCore.Asset.Command)
 # Mocking for FarmbotExt
 Mox.defmock(FarmbotExt.API, for: FarmbotExt.API)
 Mox.defmock(FarmbotExt.AMQP.ConnectionWorker, for: FarmbotExt.AMQP.ConnectionWorker)
+timeout = System.get_env("EXUNIT_TIMEOUT")
 
-ExUnit.start()
+if timeout do
+  ExUnit.start(assert_receive_timeout: String.to_integer(timeout))
+else
+  ExUnit.start()
+end


### PR DESCRIPTION
Some machines (mine) hit timeout issues on numerous `assert_receive` callbacks. This PR adds the ability to control timeouts via an `EXUNIT_TIMEOUT` ENV var.