### PR TITLE
Lookup pins before read_pin

### DIFF
--- a/farmbot_core/lib/farmbot_core/asset.ex
+++ b/farmbot_core/lib/farmbot_core/asset.ex
@@ -238,12 +238,20 @@ defmodule FarmbotCore.Asset do
     Repo.get_by(Peripheral, args)
   end
 
+  def get_peripheral_by_pin(pin) do
+    Repo.get_by(Peripheral, pin: pin)
+  end
+
   ## End Peripheral
 
   ## Begin Sensor
 
   def get_sensor(id) do
     Repo.get_by(Sensor, id: id)
+  end
+
+  def get_sensor_by_pin(pin) do
+    Repo.get_by(Sensor, pin: pin)
   end
 
   def new_sensor!(params) do


### PR DESCRIPTION
This will create sensor_values even if `NamedPin`
is not used