### PR TITLE
Change Preloading and Caching to use the same system as auto_sync

### DIFF
--- a/farmbot_core/lib/farmbot_core/asset/command.ex
+++ b/farmbot_core/lib/farmbot_core/asset/command.ex
@@ -152,6 +152,11 @@ defmodule FarmbotCore.Asset.Command do
   defp as_module!("SensorReading"), do: Asset.SensorReading 
   defp as_module!("Sequence"), do: Asset.Sequence 
   defp as_module!("Tool"), do: Asset.Tool 
+
+  defp as_module!(module) when is_atom(module) do
+    as_module!(List.last(Module.split(module)))
+  end
+  
   defp as_module!(kind) when is_binary(kind) do
     raise("""
     Unknown kind: #{kind}

--- a/farmbot_core/lib/farmbot_core/asset/regimen.ex
+++ b/farmbot_core/lib/farmbot_core/asset/regimen.ex
@@ -26,7 +26,7 @@ defmodule FarmbotCore.Asset.Regimen do
     %{
       id: regimen.id,
       name: regimen.name,
-      regimen_items: Enum.map(regimen.items, &Item.render(&1)),
+      regimen_items: Enum.map(regimen.regimen_items, &Item.render(&1)),
       body: Enum.map(regimen.body, &BodyNode.render(&1))
     }
   end

--- a/farmbot_ext/lib/farmbot_ext/amqp/auto_sync_channel.ex
+++ b/farmbot_ext/lib/farmbot_ext/amqp/auto_sync_channel.ex
@@ -72,8 +72,13 @@ defmodule FarmbotExt.AMQP.AutoSyncChannel do
   end
 
   def handle_info(:preload, state) do
-    with :ok <- Preloader.preload_all(),
-         :ok <- BotState.set_sync_status("synced") do
+    with :ok <- Preloader.preload_all() do
+      if Asset.Query.auto_sync?() do
+        BotState.set_sync_status("synced")
+      else
+        BotState.set_sync_status("sync_now")
+      end
+
       send(self(), :connect)
       {:noreply, %{state | preloaded: true}}
     else

--- a/farmbot_ext/test/farmbot_ext/amqp/auto_sync_channel_test.exs
+++ b/farmbot_ext/test/farmbot_ext/amqp/auto_sync_channel_test.exs
@@ -35,7 +35,7 @@ defmodule AutoSyncChannelTest do
 
     test_pid = self()
 
-    expect(Query, :auto_sync?, fn -> false end)
+    expect(Query, :auto_sync?, 2, fn -> false end)
 
     expect(API, :get_changeset, fn _module ->
       send(test_pid, :preload_all_called)

--- a/farmbot_os/lib/farmbot_os/sys_calls.ex
+++ b/farmbot_os/lib/farmbot_os/sys_calls.ex
@@ -16,7 +16,6 @@ defmodule FarmbotOS.SysCalls do
 
   alias FarmbotCore.{Asset, Asset.Repo, Asset.Private, Asset.Sync, BotState, Leds}
   alias FarmbotExt.{API, API.Reconciler, API.SyncGroup}
-  alias Ecto.{Changeset, Multi}
 
   @behaviour FarmbotCeleryScript.SysCalls
 
@@ -366,17 +365,12 @@ defmodule FarmbotOS.SysCalls do
     FarmbotCore.Logger.busy(3, "Syncing")
 
     with {:ok, sync_changeset} <- API.get_changeset(Sync),
-         sync <- Changeset.apply_changes(sync_changeset),
-         multi <- Multi.new(),
          :ok <- BotState.set_sync_status("syncing"),
-         {:ok, multi} <- Reconciler.sync_group(multi, sync, SyncGroup.group_0()),
-         {:ok, multi} <- Reconciler.sync_group(multi, sync, SyncGroup.group_1()),
-         {:ok, multi} <- Reconciler.sync_group(multi, sync, SyncGroup.group_2()),
-         {:ok, multi} <- Reconciler.sync_group(multi, sync, SyncGroup.group_3()),
-         {:ok, multi} <- Reconciler.sync_group(multi, sync, SyncGroup.group_4()) do
-      Multi.insert(multi, :syncs, sync_changeset)
-      |> Repo.transaction()
-
+         sync_changeset <- Reconciler.sync_group(sync_changeset, SyncGroup.group_0()),
+         sync_changeset <- Reconciler.sync_group(sync_changeset, SyncGroup.group_1()),
+         sync_changeset <- Reconciler.sync_group(sync_changeset, SyncGroup.group_2()),
+         sync_changeset <- Reconciler.sync_group(sync_changeset, SyncGroup.group_3()),
+         _sync_changeset <- Reconciler.sync_group(sync_changeset, SyncGroup.group_4()) do
       FarmbotCore.Logger.success(3, "Synced")
       :ok = BotState.set_sync_status("synced")
       :ok


### PR DESCRIPTION
* preloader and reconciler no longer use a transaction
   * This will prevent rolling back a failed sync, but allows farmbot to
   continue operating if a sync does fail
* usage of the preloader updated to reflect this