### PR TITLE
Fix reporting WiFi signal

### DIFF
--- a/farmbot_core/lib/farmbot_core/bot_state.ex
+++ b/farmbot_core/lib/farmbot_core/bot_state.ex
@@ -135,6 +135,10 @@ defmodule FarmbotCore.BotState do
     GenServer.call(bot_state_server, {:report_wifi_level, level})
   end
 
+  def report_wifi_level_percent(bot_state_server \\ __MODULE__, percent) do
+    GenServer.call(bot_state_server, {:report_wifi_level_percent, percent})
+  end
+
   def report_farmware_installed(bot_state_server \\ __MODULE__, name, %{} = manifest) do
     GenServer.call(bot_state_server, {:report_farmware_installed, name, manifest})
   end
@@ -390,6 +394,16 @@ defmodule FarmbotCore.BotState do
 
   def handle_call({:report_wifi_level, level}, _form, state) do
     change = %{informational_settings: %{wifi_level: level}}
+
+    {reply, state} =
+      BotStateNG.changeset(state.tree, change)
+      |> dispatch_and_apply(state)
+
+    {:reply, reply, state}
+  end
+
+  def handle_call({:report_wifi_level_percent, percent}, _form, state) do
+    change = %{informational_settings: %{wifi_level_percent: percent}}
 
     {reply, state} =
       BotStateNG.changeset(state.tree, change)

--- a/farmbot_core/lib/farmbot_core/bot_state_ng/informational_settings.ex
+++ b/farmbot_core/lib/farmbot_core/bot_state_ng/informational_settings.ex
@@ -19,6 +19,7 @@ defmodule FarmbotCore.BotStateNG.InformationalSettings do
     field(:soc_temp, :integer)
     field(:throttled, :string)
     field(:wifi_level, :integer)
+    field(:wifi_level_percent, :integer)
     field(:uptime, :integer)
     field(:memory_usage, :integer)
     field(:disk_usage, :integer)
@@ -49,6 +50,7 @@ defmodule FarmbotCore.BotStateNG.InformationalSettings do
       soc_temp: informational_settings.soc_temp,
       throttled: informational_settings.throttled,
       wifi_level: informational_settings.wifi_level,
+      wifi_level_percent: informational_settings.wifi_level_percent,
       uptime: informational_settings.uptime,
       memory_usage: informational_settings.memory_usage,
       disk_usage: informational_settings.disk_usage,
@@ -75,6 +77,7 @@ defmodule FarmbotCore.BotStateNG.InformationalSettings do
       :soc_temp,
       :throttled,
       :wifi_level,
+      :wifi_level_percent,
       :uptime,
       :memory_usage,
       :disk_usage,

--- a/farmbot_os/platform/target/configurator/validator.ex
+++ b/farmbot_os/platform/target/configurator/validator.ex
@@ -93,7 +93,8 @@ defmodule FarmbotOS.Platform.Target.Configurator.Validator do
     %{
       key_mgmt: :none,
       ssid: ssid,
-      scan_ssid: 1
+      scan_ssid: 1,
+      bgscan: :simple
     }
   end
 
@@ -102,7 +103,8 @@ defmodule FarmbotOS.Platform.Target.Configurator.Validator do
       ssid: ssid,
       key_mgmt: :wpa_psk,
       psk: psk,
-      scan_ssid: 1
+      scan_ssid: 1,
+      bgscan: :simple
     }
   end
 
@@ -111,7 +113,8 @@ defmodule FarmbotOS.Platform.Target.Configurator.Validator do
       ssid: ssid,
       key_mgmt: :wpa_psk,
       psk: psk,
-      scan_ssid: 1
+      scan_ssid: 1,
+      bgscan: :simple
     }
   end
 
@@ -121,7 +124,8 @@ defmodule FarmbotOS.Platform.Target.Configurator.Validator do
       key_mgmt: :wpa_eap,
       identity: id,
       password: pw,
-      scan_ssid: 1
+      scan_ssid: 1,
+      bgscan: :simple
     }
   end
 

--- a/farmbot_os/platform/target/info_workers/wifi_level.ex
+++ b/farmbot_os/platform/target/info_workers/wifi_level.ex
@@ -1,17 +1,63 @@
 defmodule FarmbotOS.Platform.Target.InfoWorker.WifiLevel do
   use GenServer
-  require Logger
+  require FarmbotCore.Logger
+  alias FarmbotCore.BotState
 
   def start_link(args) do
     GenServer.start_link(__MODULE__, args)
   end
 
   def init(_args) do
-    {:ok, %{}, 0}
+    send(self(), :load_network_config)
+    {:ok, %{ssid: nil}}
   end
 
-  def handle_info(:timeout, state) do
-    Logger.warn("Reenable wifi level worker")
+  def handle_info(:load_network_config, state) do
+    if FarmbotCore.Config.get_network_config("eth0") do
+      FarmbotCore.Logger.warn(3, """
+      FarmBot configured to use ethernet 
+      Disabling WiFi status reporting
+      """)
+
+      {:noreply, state}
+    else
+      case FarmbotCore.Config.get_network_config("wlan0") do
+        %{ssid: ssid} ->
+          VintageNet.subscribe(["interface", "wlan0"])
+          {:noreply, %{state | ssid: ssid}}
+
+        nil ->
+          Process.send_after(self(), :load_network_config, 10_000)
+          {:noreply, %{state | ssid: nil}}
+      end
+    end
+  end
+
+  def handle_info(
+        {VintageNet, ["interface", "wlan0", "wifi", "access_points"], _, new, _meta},
+        %{ssid: ssid} = state
+      )
+      when is_binary(ssid) do
+    ap =
+      Enum.find_value(new, fn
+        {_bssid, %{ssid: ^ssid} = ap} ->
+          ap
+
+        _ ->
+          false
+      end)
+
+    if ap do
+      :ok = BotState.report_wifi_level(ap.signal_dbm)
+      :ok = BotState.report_wifi_level_percent(ap.signal_percent)
+    else
+      FarmbotCore.Logger.warn(3, "WiFi scan did not report configured ssid. Skipping")
+    end
+
+    {:noreply, state}
+  end
+
+  def handle_info({VintageNet, _property, _old, _new, _meta}, state) do
     {:noreply, state}
   end
 end


### PR DESCRIPTION
* Adds new `informational_settings` field: `wifi_level_percent`.
   This uses the built in vintage_net algorithm to accurately determine
   percentage