### PR TITLE
Reenable espeaking logs

### DIFF
--- a/farmbot_core/lib/farmbot_core/log_storage/logger.ex
+++ b/farmbot_core/lib/farmbot_core/log_storage/logger.ex
@@ -89,7 +89,7 @@ defmodule FarmbotCore.Logger do
         nil -> "no_function"
       end
 
-    struct(FarmbotCore.Log,
+    struct!(FarmbotCore.Log,
       level: level,
       verbosity: verbosity,
       message: message,
@@ -116,7 +116,8 @@ defmodule FarmbotCore.Logger do
       function: log.function,
       file: log.file,
       line: log.line,
-      module: log.module
+      module: log.module,
+      channels: log.meta[:channels] || log.meta["channels"]
       # time: time
     ]
 

--- a/farmbot_os/lib/farmbot_os/init/fs_checkup.ex
+++ b/farmbot_os/lib/farmbot_os/init/fs_checkup.ex
@@ -74,7 +74,8 @@ defmodule FarmbotOS.Init.FSCheckup do
     Logger.flush()
 
     try do
-      Logger.remove_backend(:console)
+      _ = Logger.add_backend(LoggerBackendEspeak)
+      _ = Logger.remove_backend(:console)
     catch
       :exit, r ->
         IO.warn("Could not init logging: #{inspect(r)}", __STACKTRACE__)

--- a/farmbot_os/lib/farmbot_os/logger_backend_espeak.ex
+++ b/farmbot_os/lib/farmbot_os/logger_backend_espeak.ex
@@ -1,0 +1,65 @@
+defmodule LoggerBackendEspeak do
+  @moduledoc """
+  Logger backend for speaking logs outloud
+  """
+
+  @behaviour :gen_event
+
+  @impl :gen_event
+  def init(_) do
+    exe = System.find_executable("espeak")
+    send(self(), {:open, exe})
+    {:ok, %{port: nil}}
+  end
+
+  @impl :gen_event
+  def terminate(_reason, state) do
+    if state.port do
+      :erlang.port_close(state.port)
+    end
+  end
+
+  @impl :gen_event
+  def handle_event({_level, _pid, {Logger, _msg, _timestamp, _meta}}, %{port: nil} = state) do
+    {:ok, state}
+  end
+
+  def handle_event({_level, _pid, {Logger, msg, _timestamp, meta}}, %{port: espeak} = state) do
+    should_espeak? =
+      Enum.find(meta[:channels] || [], fn
+        :espeak -> true
+        "espeak" -> true
+        _ -> false
+      end)
+
+    if should_espeak? do
+      _ = Port.command(espeak, IO.iodata_to_binary(msg) <> "\n")
+    end
+
+    {:ok, state}
+  end
+
+  def handle_event(_event, state) do
+    {:ok, state}
+  end
+
+  @impl :gen_event
+  def handle_info({:open, nil}, state) do
+    {:ok, state}
+  end
+
+  def handle_info({:open, exe}, state) do
+    port = :erlang.open_port({:spawn_executable, to_charlist(exe)}, [:exit_status])
+    Port.command(port, "\n")
+    {:ok, %{state | port: port}}
+  end
+
+  def handle_info(_, state) do
+    {:ok, state}
+  end
+
+  @impl :gen_event
+  def handle_call(_, state) do
+    {:ok, :ok, state}
+  end
+end


### PR DESCRIPTION
Add a new logger backend that gets enabled on boot. Could probably be
added at compile time.