### PR TITLE
Allow firmware to be opened correctly for existing accounts

### DIFF
--- a/farmbot_core/lib/farmbot_core/asset_workers/fbos_config_worker.ex
+++ b/farmbot_core/lib/farmbot_core/asset_workers/fbos_config_worker.ex
@@ -25,6 +25,8 @@ defimpl FarmbotCore.AssetWorker, for: FarmbotCore.Asset.FbosConfig do
   def init(%FbosConfig{} = fbos_config) do
     if Config.get_config_value(:bool, "settings", "firmware_needs_flash") do
       Config.update_config_value(:bool, "settings", "firmware_needs_open", false)
+    else
+      Config.update_config_value(:bool, "settings", "firmware_needs_open", true)
     end
     {:ok, %{fbos_config: fbos_config, firmware_flash_tries: 0}, 0}
   end
@@ -92,6 +94,7 @@ defimpl FarmbotCore.AssetWorker, for: FarmbotCore.Asset.FbosConfig do
         FarmbotCeleryScript.execute(rpc, make_ref())
 
       true ->
+        Config.update_config_value(:bool, "settings", "firmware_needs_open", true)
         :ok
     end
   end

--- a/farmbot_core/lib/farmbot_core/firmware_open_task.ex
+++ b/farmbot_core/lib/farmbot_core/firmware_open_task.ex
@@ -53,6 +53,15 @@ defmodule FarmbotCore.FirmwareOpenTask do
             timer = Process.send_after(self(), :open, 5000)
             {:noreply, %{state | timer: timer}}
         end
+      true ->
+        FarmbotCore.Logger.debug 3, """
+        Unknown firmware open state:
+        firmware needs flash?: #{needs_flash?}
+        firwmare needs open?: #{needs_open?}
+        firmware path: #{firmware_path}
+        """
+        timer = Process.send_after(self(), :open, 5000)
+        {:noreply, %{state | timer: timer}}
     end
   end
 end


### PR DESCRIPTION
`firmware_path` and `firmware_needs_flash` = false is now handled
correctly