### PR TITLE
Fix updating a resource remotely not updating locally

### DIFF
--- a/farmbot_core/lib/farmbot_core/asset.ex
+++ b/farmbot_core/lib/farmbot_core/asset.ex
@@ -224,13 +224,11 @@ defmodule FarmbotCore.Asset do
   end
 
   def delete_regimen!(regimen) do
-    IO.puts "regimen instance lookup"
     regimen_instances = Repo.all(from ri in RegimenInstance, where: ri.regimen_id == ^regimen.local_id)
     for ri <- regimen_instances do
       IO.puts "deleting regimen instance: #{inspect(ri)}"
       delete_regimen_instance!(ri)
     end
-    IO.puts "deleting regimen: #{inspect(regimen)}"
     Repo.delete!(regimen)
   end
 
@@ -239,7 +237,9 @@ defmodule FarmbotCore.Asset do
     regimen_instances = Repo.all(from ri in RegimenInstance, where: ri.regimen_id == ^regimen.local_id)
     |> Repo.preload([:farm_event, :regimen])
     for ri <- regimen_instances do
-      FarmbotCore.AssetSupervisor.update_child(ri)
+      ri
+      |> RegimenInstance.changeset(%{updated_at: DateTime.utc_now()})
+      |> Repo.update!()
     end
 
     regimen

--- a/farmbot_core/lib/farmbot_core/asset/regimen_instance.ex
+++ b/farmbot_core/lib/farmbot_core/asset/regimen_instance.ex
@@ -31,7 +31,7 @@ defmodule FarmbotCore.Asset.RegimenInstance do
 
   def changeset(regimen_instance, params \\ %{}) do
     regimen_instance
-    |> cast(params, [:started_at, :next, :next_sequence_id, :monitor])
+    |> cast(params, [:started_at, :next, :next_sequence_id, :monitor, :updated_at])
     |> put_epoch()
     |> cast_assoc(:regimen)
     |> cast_assoc(:farm_event)

--- a/farmbot_ext/lib/farmbot_ext/api/reconciler.ex
+++ b/farmbot_ext/lib/farmbot_ext/api/reconciler.ex
@@ -158,15 +158,14 @@ defmodule FarmbotExt.API.Reconciler do
   defp get_changeset(%{} = local_item, %Item{} = sync_item, %Changeset{} = cached) do
     cached_updated_at = Changeset.get_field(cached, :updated_at)
     sync_item_updated_at = sync_item.updated_at
+    cache_compare = compare_datetimes(sync_item_updated_at, cached_updated_at)
 
-    if compare_datetimes(sync_item_updated_at, cached_updated_at) == :eq do
-      if compare_datetimes(cached_updated_at, local_item.updated_at) == :gt do
-        Logger.info(
-          "Local data: #{local_item.__struct__} is out of date. Using cache do get newer data."
-        )
+    if cache_compare == :eq || cache_compare == :gt do
+      Logger.info(
+        "Local data: #{local_item.__struct__} is out of date. Using cache do get newer data."
+      )
 
-        {:update, cached}
-      end
+      {:update, cached}
     else
       Logger.info("Cached item is out of date")
       get_changeset(local_item, sync_item, nil)


### PR DESCRIPTION
If a user updates any resource that updates it's own `updated_at` property but doesn't send that info back to the API, it would require an additional change to actually make it persist to farmbot os

Fixes #787 and #788 