### PR TITLE
Reenable sequence init and sequence complete logs

### DIFF
--- a/farmbot_celery_script/lib/farmbot_celery_script/ast.ex
+++ b/farmbot_celery_script/lib/farmbot_celery_script/ast.ex
@@ -19,10 +19,11 @@ defmodule FarmbotCeleryScript.AST do
           kind: kind,
           args: args,
           body: body,
-          comment: binary
+          comment: binary,
+          meta: any()
         }
 
-  defstruct [:args, :body, :kind, :comment]
+  defstruct [:args, :body, :kind, :comment, :meta]
 
   @doc "Decode a base map into CeleryScript AST."
   @spec decode(t() | map | [t() | map]) :: t()
@@ -41,12 +42,14 @@ defmodule FarmbotCeleryScript.AST do
     args = thing["args"] || thing[:args] || raise("Bad ast: #{inspect(thing)}")
     body = thing["body"] || thing[:body] || []
     comment = thing["comment"] || thing[:comment] || nil
+    meta = thing["meta"] || thing[:meta] || nil
 
     %AST{
       kind: String.to_atom(to_string(kind)),
       args: decode_args(args),
       body: decode_body(body),
-      comment: comment
+      comment: comment,
+      meta: meta
     }
   end
 
@@ -74,12 +77,13 @@ defmodule FarmbotCeleryScript.AST do
   end
 
   @spec new(atom, map, [map]) :: t()
-  def new(kind, args, body, comment \\ nil) when is_map(args) and is_list(body) do
+  def new(kind, args, body, comment \\ nil, meta \\ nil) when is_map(args) and is_list(body) do
     %AST{
       kind: String.to_atom(to_string(kind)),
       args: args,
       body: body,
-      comment: comment
+      comment: comment,
+      meta: meta
     }
     |> decode()
   end

--- a/farmbot_celery_script/lib/farmbot_celery_script/compiler/tools.ex
+++ b/farmbot_celery_script/lib/farmbot_celery_script/compiler/tools.ex
@@ -74,13 +74,29 @@ defmodule FarmbotCeleryScript.Compiler.Tools do
   end
 
   @doc false
-  defmacro compile(kind, args_pattern, body_patterrn, do: block) when is_atom(kind) do
+  defmacro compile(kind, args_pattern, body_pattern, do: block) when is_atom(kind) do
     quote do
       @kinds unquote(to_string(kind))
       def compile_ast(%AST{
             kind: unquote(kind),
             args: unquote(args_pattern),
-            body: unquote(body_patterrn)
+            body: unquote(body_pattern)
+          }) do
+        unquote(block)
+      end
+    end
+  end
+
+  @doc false
+  defmacro compile(kind, args_pattern, body_pattern, meta_pattern, do: block)
+           when is_atom(kind) do
+    quote do
+      @kinds unquote(to_string(kind))
+      def compile_ast(%AST{
+            kind: unquote(kind),
+            args: unquote(args_pattern),
+            body: unquote(body_pattern),
+            meta: unquote(meta_pattern)
           }) do
         unquote(block)
       end

--- a/farmbot_celery_script/lib/farmbot_celery_script/sys_calls.ex
+++ b/farmbot_celery_script/lib/farmbot_celery_script/sys_calls.ex
@@ -63,9 +63,19 @@ defmodule FarmbotCeleryScript.SysCalls do
   @callback zero(axis) :: ok_or_error
 
   @callback log(message :: String.t()) :: any()
+  @callback sequence_init_log(message :: String.t()) :: any()
+  @callback sequence_complete_log(message :: String.t()) :: any()
 
   def log(sys_calls \\ @sys_calls, message) when is_binary(message) do
     apply(sys_calls, :log, [message])
+  end
+
+  def sequence_init_log(sys_calls \\ @sys_calls, message) when is_binary(message) do
+    apply(sys_calls, :sequence_init_log, [message])
+  end
+
+  def sequence_complete_log(sys_calls \\ @sys_calls, message) when is_binary(message) do
+    apply(sys_calls, :sequence_complete_log, [message])
   end
 
   def calibrate(sys_calls \\ @sys_calls, axis) when axis in ["x", "y", "z"] do

--- a/farmbot_celery_script/lib/farmbot_celery_script/sys_calls/stubs.ex
+++ b/farmbot_celery_script/lib/farmbot_celery_script/sys_calls/stubs.ex
@@ -10,6 +10,12 @@ defmodule FarmbotCeleryScript.SysCalls.Stubs do
   def log(message), do: error(:log, [message])
 
   @impl true
+  def sequence_init_log(message), do: error(:log, [message])
+
+  @impl true
+  def sequence_complete_log(message), do: error(:log, [message])
+
+  @impl true
   def calibrate(axis), do: error(:calibrate, [axis])
 
   @impl true

--- a/farmbot_celery_script/test/farmbot_celery_script/compiler_test.exs
+++ b/farmbot_celery_script/test/farmbot_celery_script/compiler_test.exs
@@ -133,7 +133,6 @@ defmodule FarmbotCeleryScript.CompilerTest do
              strip_nl("""
              case(FarmbotCeleryScript.SysCalls.get_sequence(100)) do
                %FarmbotCeleryScript.AST{} = ast ->
-                 FarmbotCeleryScript.SysCalls.log("Executing Sequence")
                  env = []
                  FarmbotCeleryScript.Compiler.compile(ast, env)
 

--- a/farmbot_os/lib/farmbot_os/sys_calls.ex
+++ b/farmbot_os/lib/farmbot_os/sys_calls.ex
@@ -61,6 +61,26 @@ defmodule FarmbotOS.SysCalls do
   end
 
   @impl true
+  def sequence_init_log(message) do
+    if FarmbotCore.Asset.fbos_config(:sequence_init_log) do
+      FarmbotCore.Logger.info(2, message)
+      :ok
+    else
+      :ok
+    end
+  end
+
+  @impl true
+  def sequence_complete_log(message) do
+    if FarmbotCore.Asset.fbos_config(:sequence_complete_log) do
+      FarmbotCore.Logger.info(2, message)
+      :ok
+    else
+      :ok
+    end
+  end
+
+  @impl true
   def reboot do
     FarmbotOS.System.reboot("Reboot requested by Sequence or frontend")
     :ok
@@ -482,8 +502,11 @@ defmodule FarmbotOS.SysCalls do
   @impl true
   def get_sequence(id) do
     case Asset.get_sequence(id) do
-      nil -> {:error, "sequence not found"}
-      %{} = sequence -> AST.decode(sequence)
+      nil ->
+        {:error, "sequence not found"}
+
+      %{} = sequence ->
+        %{AST.decode(sequence) | meta: %{sequence_name: sequence.name}}
     end
   end
 

--- a/test/support/celery_script/test_sys_calls.ex
+++ b/test/support/celery_script/test_sys_calls.ex
@@ -47,6 +47,16 @@ defmodule Farmbot.TestSupport.CeleryScript.TestSysCalls do
   end
 
   @impl true
+  def sequence_init_log(_message) do
+    :ok
+  end
+
+  @impl true
+  def sequence_complete_log(_message) do
+    :ok
+  end
+
+  @impl true
   def coordinate(x, y, z) do
     %{x: x, y: y, z: z}
   end


### PR DESCRIPTION
Sort of a hack, but store some metadata about a sequence in the AST
format, and if it exists, log it