### PR TITLE
Allow firmware to be open/flashed infinity times

### DIFF
--- a/farmbot_core/config/config.exs
+++ b/farmbot_core/config/config.exs
@@ -11,7 +11,7 @@ config :farmbot_core, FarmbotCore.AssetWorker.FarmbotCore.Asset.FarmwareInstalla
 
 config :farmbot_core, FarmbotCore.FarmwareRuntime, runtime_dir: "/tmp/farmware_runtime"
 
-config :farmbot_core, Elixir.FarmbotCore.AssetWorker.FarmbotCore.Asset.PinBinding,
+config :farmbot_core, FarmbotCore.AssetWorker.FarmbotCore.Asset.PinBinding,
   gpio_handler: FarmbotCore.PinBindingWorker.StubGPIOHandler,
   error_retry_time_ms: 30_000
 
@@ -38,6 +38,9 @@ config :farmbot_core, FarmbotCore.EctoMigrator,
 config :farmbot_core, FarmbotCore.FirmwareTTYDetector, expected_names: []
 
 config :farmbot_core, FarmbotCore.FirmwareOpenTask, attempt_threshold: 5
+
+config :farmbot_core, FarmbotCore.AssetWorker.FarmbotCore.Asset.FbosConfig,
+  firmware_flash_attempt_threshold: 5
 
 import_config "ecto.exs"
 import_config "logger.exs"

--- a/farmbot_core/config/dev.exs
+++ b/farmbot_core/config/dev.exs
@@ -2,3 +2,8 @@ use Mix.Config
 
 config :farmbot_celery_script, FarmbotCeleryScript.SysCalls,
   sys_calls: FarmbotCeleryScript.SysCalls.Stubs
+
+config :farmbot_core, FarmbotCore.FirmwareOpenTask, attempt_threshold: 5
+
+config :farmbot_core, FarmbotCore.AssetWorker.FarmbotCore.Asset.FbosConfig,
+  firmware_flash_attempt_threshold: 5

--- a/farmbot_core/config/test.exs
+++ b/farmbot_core/config/test.exs
@@ -11,3 +11,8 @@ config :farmbot_core, FarmbotCore.AssetWorker.FarmbotCore.Asset.RegimenInstance,
 
 config :farmbot_celery_script, FarmbotCeleryScript.SysCalls,
   sys_calls: Farmbot.TestSupport.CeleryScript.TestSysCalls
+
+config :farmbot_core, FarmbotCore.FirmwareOpenTask, attempt_threshold: 0
+
+config :farmbot_core, FarmbotCore.AssetWorker.FarmbotCore.Asset.FbosConfig,
+  firmware_flash_attempt_threshold: 0

--- a/farmbot_core/lib/farmbot_core/firmware_tty_detector.ex
+++ b/farmbot_core/lib/farmbot_core/firmware_tty_detector.ex
@@ -14,12 +14,18 @@ defmodule FarmbotCore.FirmwareTTYDetector do
 
   @error_retry_ms 5_000
 
+  @doc "Gets the detected TTY"
   def tty(server \\ __MODULE__) do
     GenServer.call(server, :tty)
   end
 
   def tty!(server \\ __MODULE__) do
     tty(server) || raise "No TTY detected"
+  end
+
+  @doc "Sets a TTY as detected by some other means"
+  def set_tty(server \\ __MODULE__, tty) when is_binary(tty) do
+    GenServer.call(server, {:tty, tty})
   end
 
   def start_link(args, opts \\ [name: __MODULE__]) do
@@ -32,6 +38,10 @@ defmodule FarmbotCore.FirmwareTTYDetector do
 
   def handle_call(:tty, _, detected_tty) do
     {:reply, detected_tty, detected_tty}
+  end
+
+  def handle_call({:tty, detected_tty}, _from, _old_value) do
+    {:reply, :ok, detected_tty}
   end
 
   def handle_info(:timeout, state) do

--- a/farmbot_ext/config/farmbot_core.exs
+++ b/farmbot_ext/config/farmbot_core.exs
@@ -4,7 +4,7 @@ config :farmbot_core, FarmbotCore.AssetWorker.FarmbotCore.Asset.FarmEvent, check
 config :farmbot_core, FarmbotCore.AssetWorker.FarmbotCore.Asset.RegimenInstance,
   checkup_time_ms: 10_000
 
-config :farmbot_core, Elixir.FarmbotCore.AssetWorker.FarmbotCore.Asset.PinBinding,
+config :farmbot_core, FarmbotCore.AssetWorker.FarmbotCore.Asset.PinBinding,
   gpio_handler: FarmbotCore.PinBindingWorker.StubGPIOHandler,
   error_retry_time_ms: 30_000
 
@@ -38,4 +38,7 @@ config :farmbot_core, FarmbotCore.EctoMigrator,
 
 config :farmbot_core, FarmbotCore.FirmwareTTYDetector, expected_names: []
 
-config :farmbot_core, FarmbotCore.FirmwareOpenTask, attempt_threshold: 5
+config :farmbot_core, FarmbotCore.FirmwareOpenTask, attempt_threshold: 0
+
+config :farmbot_core, FarmbotCore.AssetWorker.FarmbotCore.Asset.FbosConfig,
+  firmware_flash_attempt_threshold: 0

--- a/farmbot_firmware/lib/farmbot_firmware.ex
+++ b/farmbot_firmware/lib/farmbot_firmware.ex
@@ -673,6 +673,10 @@ defmodule FarmbotFirmware do
       old != new && old == :emergency_lock ->
         side_effects(new_state, :handle_emergency_unlock, [])
 
+      # Boot up emergency unlock
+      old == :boot && new != :emergency_lock ->
+        side_effects(new_state, :handle_emergency_unlock, [])
+
       old == new ->
         :ok
 

--- a/farmbot_os/config/host/dev.exs
+++ b/farmbot_os/config/host/dev.exs
@@ -39,5 +39,8 @@ config :farmbot_core, FarmbotCore.FirmwareTTYDetector,
 
 config :farmbot_core, FarmbotCore.FirmwareOpenTask, attempt_threshold: 5
 
+config :farmbot_core, FarmbotCore.AssetWorker.FarmbotCore.Asset.FbosConfig,
+  firmware_flash_attempt_threshold: 5
+
 config :logger,
   backends: [:console]

--- a/farmbot_os/config/host/test.exs
+++ b/farmbot_os/config/host/test.exs
@@ -35,4 +35,7 @@ config :farmbot_core, FarmbotCore.FirmwareTTYDetector, expected_names: []
 
 config :farmbot_core, FarmbotCore.FirmwareOpenTask, attempt_threshold: 0
 
+config :farmbot_core, FarmbotCore.AssetWorker.FarmbotCore.Asset.FbosConfig,
+  firmware_flash_attempt_threshold: 0
+
 config :plug, :validate_header_keys_during_test, true

--- a/farmbot_os/config/target/dev.exs
+++ b/farmbot_os/config/target/dev.exs
@@ -72,6 +72,9 @@ config :nerves_hub, NervesHub.Socket, reconnect_interval: 5_000
 
 config :farmbot_core, FarmbotCore.FirmwareOpenTask, attempt_threshold: 5
 
+config :farmbot_core, FarmbotCore.AssetWorker.FarmbotCore.Asset.FbosConfig,
+  firmware_flash_attempt_threshold: 5
+
 config :logger, backends: [RingLogger]
 
 config :logger, RingLogger,

--- a/farmbot_os/config/target/prod.exs
+++ b/farmbot_os/config/target/prod.exs
@@ -72,6 +72,9 @@ config :nerves_hub, NervesHub.Socket, reconnect_interval: 30_000
 
 config :farmbot_core, FarmbotCore.FirmwareOpenTask, attempt_threshold: 5_000_000
 
+config :farmbot_core, FarmbotCore.AssetWorker.FarmbotCore.Asset.FbosConfig,
+  firmware_flash_attempt_threshold: :infinity
+
 config :logger,
   backends: [RingLogger],
   handle_otp_reports: true,


### PR DESCRIPTION
* add `infinity` as an option for `fbos_config_worker` and
`firmware_open_task`
* reenable uevent montior flashing/opening firmware

Fixes #814 
Fixes #815 
Fixes #816 