### PR TITLE
Fix scheduler not reindexing when an event is missed

### DIFF
--- a/farmbot_celery_script/lib/farmbot_celery_script.ex
+++ b/farmbot_celery_script/lib/farmbot_celery_script.ex
@@ -6,8 +6,8 @@ defmodule FarmbotCeleryScript do
   alias FarmbotCeleryScript.{AST, Scheduler, StepRunner}
 
   @doc "Schedule an AST to execute on a DateTime"
-  def schedule(%AST{} = ast, %DateTime{} = at) do
-    Scheduler.schedule(ast, at)
+  def schedule(%AST{} = ast, %DateTime{} = at, %{} = data) do
+    Scheduler.schedule(ast, at, data)
   end
 
   @doc "Execute an AST in place"

--- a/farmbot_celery_script/test/farmbot_celery_script/scheduler_test.exs
+++ b/farmbot_celery_script/test/farmbot_celery_script/scheduler_test.exs
@@ -25,7 +25,7 @@ defmodule FarmbotCeleryScript.SchedulerTest do
       end)
 
     scheduled_time = DateTime.utc_now() |> DateTime.add(100, :millisecond)
-    {:ok, _} = Scheduler.schedule(sch, ast, scheduled_time)
+    {:ok, _} = Scheduler.schedule(sch, ast, scheduled_time, %{})
     assert_receive {:read_pin, [9, 0]}, 1000
   end
 end

--- a/farmbot_core/lib/farmbot_core/asset_workers/farm_event_worker/sequence_event.ex
+++ b/farmbot_core/lib/farmbot_core/asset_workers/farm_event_worker/sequence_event.ex
@@ -54,6 +54,6 @@ defmodule FarmbotCore.FarmEventWorker.SequenceEvent do
           | locals: %{celery_ast.args.locals | body: celery_ast.args.locals.body ++ param_appls}
         }
     }
-    FarmbotCeleryScript.schedule(celery_ast, at)
+    FarmbotCeleryScript.schedule(celery_ast, at, farm_event)
   end
 end

--- a/farmbot_core/lib/farmbot_core/asset_workers/regimen_instance_worker.ex
+++ b/farmbot_core/lib/farmbot_core/asset_workers/regimen_instance_worker.ex
@@ -88,6 +88,6 @@ defimpl FarmbotCore.AssetWorker, for: FarmbotCore.Asset.RegimenInstance do
             celery_ast.args.locals | body: celery_ast.args.locals.body ++ regimen_params ++ farm_event_params}
         }
     }
-    FarmbotCeleryScript.schedule(celery_ast, at)
+    FarmbotCeleryScript.schedule(celery_ast, at, regimen_instance)
   end
 end


### PR DESCRIPTION
* Add some breadcrumbs to see what the data that generated the scheduled
event looks like
* only monitor a process if it isn't monitored yet

Fixes #788 