### PR TITLE
Only generate calculate in the future

### DIFF
--- a/farmbot_core/lib/farmbot_core/asset_workers/farm_event_worker/sequence_event.ex
+++ b/farmbot_core/lib/farmbot_core/asset_workers/farm_event_worker/sequence_event.ex
@@ -2,7 +2,7 @@ defmodule FarmbotCore.FarmEventWorker.SequenceEvent do
   require Logger
   alias FarmbotCeleryScript.AST
   alias FarmbotCore.{
-    Asset, 
+    Asset,
     Asset.FarmEvent
   }
   use GenServer
@@ -18,12 +18,12 @@ defmodule FarmbotCore.FarmEventWorker.SequenceEvent do
     farm_event = state.farm_event
 
     farm_event
-    |> FarmEvent.build_calendar(farm_event.start_time)
+    |> FarmEvent.build_calendar(DateTime.utc_now())
     # get rid of any item that has already been scheduled/executed
-    |> Enum.reject(fn(scheduled_at) -> 
+    |> Enum.reject(fn(scheduled_at) ->
       Asset.get_farm_event_execution(farm_event, scheduled_at)
     end)
-    |> Enum.each(fn(at) -> 
+    |> Enum.each(fn(at) ->
       schedule_sequence(farm_event, at)
     end)
     {:noreply, state}


### PR DESCRIPTION
This prevents backscheduling in cases of farmbot rebooting or going
offline