### PR TITLE
Allow a `none` option for fbos_config.firmware_hardware

### DIFF
--- a/farmbot_core/lib/farmbot_core/asset_workers/fbos_config_worker.ex
+++ b/farmbot_core/lib/farmbot_core/asset_workers/fbos_config_worker.ex
@@ -85,6 +85,12 @@ defimpl FarmbotCore.AssetWorker, for: FarmbotCore.Asset.FbosConfig do
     {:noreply, %{state | fbos_config: new_fbos_config}}
   end
 
+  def maybe_flash_firmware(%{firmware_hardware: "none"} = _new_fbow_config, _ = _old_fbos_config) do
+    Config.update_config_value(:bool, "settings", "firmware_needs_flash", false)
+    Config.update_config_value(:bool, "settings", "firmware_needs_open", true)
+    :ok
+  end
+
   def maybe_flash_firmware(%{firmware_hardware: new_hardware} = new_fbos_config, %{firmware_hardware: old_hardware}) do
     force? = Config.get_config_value(:bool, "settings", "firmware_needs_flash")
     cond do

--- a/farmbot_core/lib/farmbot_core/firmware_side_effects.ex
+++ b/farmbot_core/lib/farmbot_core/firmware_side_effects.ex
@@ -71,7 +71,8 @@ defmodule FarmbotCore.FirmwareSideEffects do
       [_, _, _, "E"] ->
         :ok = BotState.set_firmware_hardware("express_k10")
       [_, _, _, "S"] ->
-        :ok = BotState.set_firmware_hardware("stubduino")
+        :ok = BotState.set_firmware_version("none")
+        :ok = BotState.set_firmware_hardware("none")
     end
   end
 


### PR DESCRIPTION
Fixes #843 