### PR TITLE
kill kmsg tailer when nerves_runtime exits and only connect to NervesHub once

### DIFF
--- a/farmbot_os/platform/target/shoehorn_handler.ex
+++ b/farmbot_os/platform/target/shoehorn_handler.ex
@@ -7,6 +7,12 @@ defmodule FarmbotOS.Platform.Target.ShoehornHandler do
     {:ok, %{restart_counts: 0}}
   end
 
+  def application_exited(:nerves_runtime, _, state) do
+    # https://github.com/nerves-project/nerves_runtime/issues/152
+    _ = System.cmd("killall", ["-9", "kmsg_tailer"], into: IO.stream(:stdio, :line))
+    {:continue, state}
+  end
+
   def application_exited(app, reason, %{restart_counts: count} = state)
       when count >= 5 and
              app in [


### PR DESCRIPTION
Fixes #862 