### PR TITLE
Add child_spec to FarmbotCore.Led

### DIFF
--- a/farmbot_core/lib/farmbot_core.ex
+++ b/farmbot_core/lib/farmbot_core.ex
@@ -16,6 +16,7 @@ defmodule FarmbotCore do
   def init([]) do
 
     children = [
+      FarmbotCore.Leds,
       FarmbotCore.EctoMigrator,
       FarmbotCore.BotState.Supervisor,
       FarmbotCore.StorageSupervisor,

--- a/farmbot_core/lib/farmbot_core/leds/led_handler.ex
+++ b/farmbot_core/lib/farmbot_core/leds/led_handler.ex
@@ -13,4 +13,6 @@ defmodule FarmbotCore.Leds.Handler do
   @callback white3(status) :: any
   @callback white4(status) :: any
   @callback white5(status) :: any
+
+  @callback start_link(any) :: GenServer.on_start()
 end

--- a/farmbot_core/lib/farmbot_core/leds/leds.ex
+++ b/farmbot_core/lib/farmbot_core/leds/leds.ex
@@ -17,4 +17,14 @@ defmodule FarmbotCore.Leds do
 
   defp led_handler,
     do: Application.get_env(:farmbot_core, __MODULE__)[:gpio_handler]
+
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {led_handler(), :start_link, [opts]},
+      type: :worker,
+      restart: :permanent,
+      shutdown: 500
+    }
+  end
 end

--- a/farmbot_core/lib/farmbot_core/leds/stub_handler.ex
+++ b/farmbot_core/lib/farmbot_core/leds/stub_handler.ex
@@ -32,4 +32,8 @@ defmodule FarmbotCore.Leds.StubHandler do
   defp status_out(:slow_blink), do: IO.ANSI.blink_off()
   defp status_out(:fast_blink), do: IO.ANSI.blink_off()
   defp status_out(_), do: ""
+
+  def start_link(_args) do
+    :ignore
+  end
 end

--- a/farmbot_os/config/target/rpi.exs
+++ b/farmbot_os/config/target/rpi.exs
@@ -7,6 +7,5 @@ config :farmbot_firmware, FarmbotFirmware.UARTTransport,
 
 config :farmbot, FarmbotOS.Init.Supervisor,
   init_children: [
-    FarmbotOS.Platform.Target.FirmwareReset.GPIO,
-    FarmbotOS.Platform.Target.Leds.CircuitsHandler
+    FarmbotOS.Platform.Target.FirmwareReset.GPIO
   ]

--- a/farmbot_os/config/target/rpi0.exs
+++ b/farmbot_os/config/target/rpi0.exs
@@ -9,6 +9,5 @@ config :farmbot_firmware, FarmbotFirmware.UARTTransport,
 
 config :farmbot, FarmbotOS.Init.Supervisor,
   init_children: [
-    FarmbotOS.Platform.Target.FirmwareReset.GPIO,
-    FarmbotOS.Platform.Target.Leds.CircuitsHandler
+    FarmbotOS.Platform.Target.FirmwareReset.GPIO
   ]

--- a/farmbot_os/config/target/rpi3.exs
+++ b/farmbot_os/config/target/rpi3.exs
@@ -5,7 +5,4 @@ config :farmbot_core, FarmbotCore.FirmwareTTYDetector, expected_names: ["ttyUSB0
 config :farmbot_firmware, FarmbotFirmware.UARTTransport,
   reset: FarmbotOS.Platform.Target.FirmwareReset.NULL
 
-config :farmbot, FarmbotOS.Init.Supervisor,
-  init_children: [
-    FarmbotOS.Platform.Target.Leds.CircuitsHandler
-  ]
+config :farmbot, FarmbotOS.Init.Supervisor, init_children: []


### PR DESCRIPTION
Allows LED handler to start _before_ farmbto_os starts