### PR TITLE
Add ability to add ssh keys at runtime

### DIFF
--- a/farmbot_core/config/config.exs
+++ b/farmbot_core/config/config.exs
@@ -15,6 +15,9 @@ config :farmbot_core, FarmbotCore.AssetWorker.FarmbotCore.Asset.PinBinding,
   gpio_handler: FarmbotCore.PinBindingWorker.StubGPIOHandler,
   error_retry_time_ms: 30_000
 
+config :farmbot_core, Elixir.FarmbotCore.AssetWorker.FarmbotCore.Asset.PublicKey,
+  ssh_handler: FarmbotCore.PublicKeyHandler.StubSSHHandler
+
 config :farmbot_core, FarmbotCore.AssetMonitor, checkup_time_ms: 30_000
 
 config :farmbot_core, FarmbotCore.Leds, gpio_handler: FarmbotCore.Leds.StubHandler

--- a/farmbot_core/lib/farmbot_core/asset.ex
+++ b/farmbot_core/lib/farmbot_core/asset.ex
@@ -245,6 +245,14 @@ defmodule FarmbotCore.Asset do
   def delete_public_key!(public_key) do
     Repo.delete!(public_key)
   end
+
+  def new_public_key_from_home!() do
+    public_key_path = Path.join([System.get_env("HOME"), ".ssh", "id_rsa.pub"])
+    public_key = File.read!(public_key_path)
+    %PublicKey{}
+    |> PublicKey.changeset(%{public_key: public_key, name: "id_rsa.pub"})
+    |> Repo.insert()
+  end
   
   ## End PublicKey
 

--- a/farmbot_core/lib/farmbot_core/asset.ex
+++ b/farmbot_core/lib/farmbot_core/asset.ex
@@ -250,7 +250,13 @@ defmodule FarmbotCore.Asset do
     public_key_path = Path.join([System.get_env("HOME"), ".ssh", "id_rsa.pub"])
     public_key = File.read!(public_key_path)
     %PublicKey{}
-    |> PublicKey.changeset(%{public_key: public_key, name: "id_rsa.pub"})
+    |> PublicKey.changeset(%{public_key: public_key})
+    |> Repo.insert()
+  end
+
+  def new_public_key_from_string!(public_key) do
+    %PublicKey{}
+    |> PublicKey.changeset(%{public_key: public_key})
     |> Repo.insert()
   end
   

--- a/farmbot_core/lib/farmbot_core/asset.ex
+++ b/farmbot_core/lib/farmbot_core/asset.ex
@@ -18,6 +18,7 @@ defmodule FarmbotCore.Asset do
     Peripheral,
     PinBinding,
     Point,
+    PublicKey,
     Regimen,
     RegimenInstance,
     Sequence,
@@ -222,6 +223,30 @@ defmodule FarmbotCore.Asset do
   end
 
   ## End Point
+
+  ## Begin PublicKey
+
+  def get_public_key(id) do
+    Repo.get_by(PublicKey, id: id)
+  end
+
+  def new_public_key!(params) do
+    %PublicKey{}
+    |> PublicKey.changeset(params)
+    |> Repo.insert!()
+  end
+
+  def update_public_key!(public_key, params) do
+    public_key
+    |> PublicKey.changeset(params)
+    |> Repo.update!()
+  end
+
+  def delete_public_key!(public_key) do
+    Repo.delete!(public_key)
+  end
+  
+  ## End PublicKey
 
   ## Begin Regimen
 

--- a/farmbot_core/lib/farmbot_core/asset/command.ex
+++ b/farmbot_core/lib/farmbot_core/asset/command.ex
@@ -12,7 +12,7 @@ defmodule FarmbotCore.Asset.Command do
     FarmwareInstallation,
     FbosConfig,
     FirmwareConfig,
-    Regimen,
+    PublicKey,
     Regimen,
     Sensor,
     SensorReading,
@@ -77,6 +77,12 @@ defmodule FarmbotCore.Asset.Command do
     :ok
   end
 
+  def update(PublicKey, id, nil) do
+    public_key = Asset.get_public_key(id)
+    public_key && Asset.delete_public_key!(public_key)
+    :ok
+  end
+
   def update(Regimen, id, nil) do
     regimen = Asset.get_regimen(id)
     regimen && Asset.delete_regimen!(regimen)
@@ -105,6 +111,15 @@ defmodule FarmbotCore.Asset.Command do
       do: Asset.update_farm_event!(old, params), 
       else: Asset.new_farm_event!(params)
     
+    :ok
+  end
+
+  def update(PublicKey, id, params) do
+    old = Asset.get_public_key(id)
+    if old,
+      do: Asset.update_public_key!(old, params),
+      else: Asset.new_public_key!(params)
+
     :ok
   end
 

--- a/farmbot_core/lib/farmbot_core/asset/private/local_meta.ex
+++ b/farmbot_core/lib/farmbot_core/asset/private/local_meta.ex
@@ -19,6 +19,7 @@ defmodule FarmbotCore.Asset.Private.LocalMeta do
     Peripheral,
     PinBinding,
     Point,
+    PublicKey,
     Regimen,
     SensorReading,
     Sensor,
@@ -103,6 +104,13 @@ defmodule FarmbotCore.Asset.Private.LocalMeta do
     )
 
     belongs_to(:point, Point,
+      foreign_key: :asset_local_id,
+      type: :binary_id,
+      references: :local_id,
+      define_field: false
+    )
+
+    belongs_to(:public_key, PublicKey,
       foreign_key: :asset_local_id,
       type: :binary_id,
       references: :local_id,

--- a/farmbot_core/lib/farmbot_core/asset/public_key.ex
+++ b/farmbot_core/lib/farmbot_core/asset/public_key.ex
@@ -1,0 +1,37 @@
+defmodule FarmbotCore.Asset.PublicKey do
+  @moduledoc """
+  Public keys can be used to SSH into a device for
+  debug purposes
+  """
+
+  use FarmbotCore.Asset.Schema, path: "/api/public_keys"
+
+  schema "public_keys" do
+    field(:id, :id)
+
+    has_one(:local_meta, FarmbotCore.Asset.Private.LocalMeta,
+      on_delete: :delete_all,
+      references: :local_id,
+      foreign_key: :asset_local_id
+    )
+
+    field(:name, :string)
+    field(:public_key, :string)
+    field(:monitor, :boolean, default: true)
+    timestamps()
+  end
+
+  view public_key do
+    %{
+      id: public_key.id,
+      name: public_key.name,
+      public_key: public_key.public_key
+    }
+  end
+
+  def changeset(public_key, params \\ %{}) do
+    public_key
+    |> cast(params, [:id, :name, :public_key, :monitor, :created_at, :updated_at])
+    |> validate_required([])
+  end
+end

--- a/farmbot_core/lib/farmbot_core/asset/public_key.ex
+++ b/farmbot_core/lib/farmbot_core/asset/public_key.ex
@@ -5,6 +5,7 @@ defmodule FarmbotCore.Asset.PublicKey do
   """
 
   use FarmbotCore.Asset.Schema, path: "/api/public_keys"
+  alias Ecto.Changeset
 
   @callback ready?() :: boolean()
   @callback add_key(map()) :: :ok | term()
@@ -35,6 +36,33 @@ defmodule FarmbotCore.Asset.PublicKey do
   def changeset(public_key, params \\ %{}) do
     public_key
     |> cast(params, [:id, :name, :public_key, :monitor, :created_at, :updated_at])
-    |> validate_required([])
+    |> validate_required([:public_key])
+    |> validate_rsa()
+  end
+
+  def validate_rsa(%Changeset{valid?: true} = changeset) do
+    public_key_bin = get_field(changeset, :public_key)
+    case :public_key.ssh_decode(public_key_bin, :auth_keys) do
+      [{_, opts}] -> 
+        maybe_add_name(changeset, opts[:comment])
+      [_ | _] -> 
+        add_error(changeset, :public_key, "should only contain 1 key")
+      _ ->
+        add_error(changeset, :public_key, "could not decode public key")
+    end
+  end
+
+  def validate_rsa(changeset), do: changeset
+
+  def maybe_add_name(changeset, nil) do
+    changeset
+  end
+
+  def maybe_add_name(changeset, comment) do
+    if get_field(changeset, :name) do
+      changeset
+    else
+      put_change(changeset, :name, to_string(comment))
+    end
   end
 end

--- a/farmbot_core/lib/farmbot_core/asset/public_key.ex
+++ b/farmbot_core/lib/farmbot_core/asset/public_key.ex
@@ -6,6 +6,9 @@ defmodule FarmbotCore.Asset.PublicKey do
 
   use FarmbotCore.Asset.Schema, path: "/api/public_keys"
 
+  @callback ready?() :: boolean()
+  @callback add_key(map()) :: :ok | term()
+
   schema "public_keys" do
     field(:id, :id)
 

--- a/farmbot_core/lib/farmbot_core/asset/supervisor.ex
+++ b/farmbot_core/lib/farmbot_core/asset/supervisor.ex
@@ -12,6 +12,7 @@ defmodule FarmbotCore.Asset.Supervisor do
     FbosConfig,
     FirmwareConfig,
     PinBinding,
+    PublicKey,
     Peripheral,
     RegimenInstance
   }
@@ -29,6 +30,7 @@ defmodule FarmbotCore.Asset.Supervisor do
       {AssetSupervisor, module: RegimenInstance},
       {AssetSupervisor, module: FarmEvent},
       {AssetSupervisor, module: PinBinding},
+      {AssetSupervisor, module: PublicKey},
       {AssetSupervisor, module: Peripheral},
       {AssetSupervisor, module: FarmwareInstallation},
       {AssetSupervisor, module: FarmwareEnv},

--- a/farmbot_core/lib/farmbot_core/asset/sync.ex
+++ b/farmbot_core/lib/farmbot_core/asset/sync.ex
@@ -48,6 +48,7 @@ defmodule FarmbotCore.Asset.Sync do
     embeds_many(:peripherals, Item)
     embeds_many(:pin_bindings, Item)
     embeds_many(:points, Item)
+    embeds_many(:public_keys, Item)
     embeds_many(:regimens, Item)
     embeds_many(:sensor_readings, Item)
     embeds_many(:sensors, Item)
@@ -69,6 +70,7 @@ defmodule FarmbotCore.Asset.Sync do
       peripherals: Enum.map(sync.peripherals, &Item.render/1),
       pin_bindings: Enum.map(sync.pin_bindings, &Item.render/1),
       points: Enum.map(sync.points, &Item.render/1),
+      public_keys: Enum.map(sync.public_keys, &Item.render/1),
       regimens: Enum.map(sync.regimens, &Item.render/1),
       sensor_readings: Enum.map(sync.sensor_readings, &Item.render/1),
       sensors: Enum.map(sync.sensors, &Item.render/1),
@@ -91,6 +93,7 @@ defmodule FarmbotCore.Asset.Sync do
     |> cast_embed(:peripherals)
     |> cast_embed(:pin_bindings)
     |> cast_embed(:points)
+    |> cast_embed(:public_keys)
     |> cast_embed(:regimens)
     |> cast_embed(:sensor_readings)
     |> cast_embed(:sensors)

--- a/farmbot_core/lib/farmbot_core/asset_helpers.ex
+++ b/farmbot_core/lib/farmbot_core/asset_helpers.ex
@@ -28,6 +28,7 @@ defmodule FarmbotCore.AssetHelpers do
         Peripheral,
         PinBinding,
         Point,
+        PublicKey,
         Regimen,
         RegimenInstance,
         Sequence,

--- a/farmbot_core/lib/farmbot_core/asset_monitor.ex
+++ b/farmbot_core/lib/farmbot_core/asset_monitor.ex
@@ -18,6 +18,7 @@ defmodule FarmbotCore.AssetMonitor do
     Peripheral,
     RegimenInstance,
     PinBinding,
+    PublicKey
   }
 
   alias FarmbotCore.{AssetSupervisor, AssetWorker}
@@ -123,6 +124,7 @@ defmodule FarmbotCore.AssetMonitor do
       Peripheral,
       RegimenInstance,
       PinBinding,
+      PublicKey,
       FarmwareInstallation,
       FarmwareEnv
     ]

--- a/farmbot_core/lib/farmbot_core/asset_workers/public_key_worker.ex
+++ b/farmbot_core/lib/farmbot_core/asset_workers/public_key_worker.ex
@@ -1,0 +1,20 @@
+defimpl FarmbotCore.AssetWorker, for: FarmbotCore.Asset.PublicKey do
+  alias FarmbotCore.Asset.PublicKey
+  use GenServer
+
+  def tracks_changes?(%PublicKey{}), do: false
+
+  def preload(%PublicKey{}), do: []
+
+  def start_link(%PublicKey{} = public_key, _args) do
+    GenServer.start_link(__MODULE__, %PublicKey{} = public_key)
+  end
+
+  def init(%PublicKey{} = public_key) do
+    {:ok, %PublicKey{} = public_key, 0}
+  end
+
+  def handle_info(:timeout, %PublicKey{} = public_key) do
+    {:noreply, public_key}
+  end
+end

--- a/farmbot_core/lib/farmbot_core/asset_workers/public_key_worker.ex
+++ b/farmbot_core/lib/farmbot_core/asset_workers/public_key_worker.ex
@@ -2,6 +2,13 @@ defimpl FarmbotCore.AssetWorker, for: FarmbotCore.Asset.PublicKey do
   alias FarmbotCore.Asset.PublicKey
   use GenServer
 
+  @ssh_handler Application.get_env(:farmbot_core, __MODULE__)[:ssh_handler]
+  @ssh_handler ||
+    Mix.raise("""
+      config :farmbot_core, #{__MODULE__}, 
+        ssh_handler: FarmbotCore.PublicKeyHandler.StubSSHHandler
+    """)
+
   def tracks_changes?(%PublicKey{}), do: false
 
   def preload(%PublicKey{}), do: []
@@ -11,10 +18,19 @@ defimpl FarmbotCore.AssetWorker, for: FarmbotCore.Asset.PublicKey do
   end
 
   def init(%PublicKey{} = public_key) do
-    {:ok, %PublicKey{} = public_key, 0}
+    {:ok, %{public_key: public_key}, 0}
   end
 
-  def handle_info(:timeout, %PublicKey{} = public_key) do
-    {:noreply, public_key}
+  def handle_info(:timeout, state) do
+    if ssh_handler().ready?() do
+      ssh_handler().add_key(state.public_key)
+      {:noreply, state}
+    else
+      {:noreply, state, 5000}
+    end
+  end
+
+  def ssh_handler() do
+    Application.get_env(:farmbot_core, __MODULE__)[:ssh_handler]
   end
 end

--- a/farmbot_core/lib/farmbot_core/asset_workers/public_key_worker/stub_ssh_handler.ex
+++ b/farmbot_core/lib/farmbot_core/asset_workers/public_key_worker/stub_ssh_handler.ex
@@ -1,0 +1,5 @@
+defmodule FarmbotCore.PublicKeyHandler.StubSSHHandler do
+  @behaviour FarmbotCore.Asset.PublicKey
+  def ready?(), do: true
+  def add_key(_key), do: :ok
+end

--- a/farmbot_core/priv/asset/migrations/20190724183349_create_public_keys_table.exs
+++ b/farmbot_core/priv/asset/migrations/20190724183349_create_public_keys_table.exs
@@ -1,0 +1,20 @@
+defmodule FarmbotCore.Asset.Repo.Migrations.CreatePublicKeysTable do
+  use Ecto.Migration
+
+  def change do
+    create table("public_keys", primary_key: false) do
+      add(:local_id, :binary_id, primary_key: true)
+      add(:id, :id)
+      add(:name, :string)
+      add(:public_key, :string)
+      add(:monitor, :boolean, default: true)
+      timestamps(inserted_at: :created_at, type: :utc_datetime)
+    end
+
+    create(unique_index("public_keys", :id))
+
+    alter table("syncs") do
+      add(:public_keys, {:array, :map})
+    end
+  end
+end

--- a/farmbot_ext/config/farmbot_core.exs
+++ b/farmbot_ext/config/farmbot_core.exs
@@ -8,6 +8,9 @@ config :farmbot_core, FarmbotCore.AssetWorker.FarmbotCore.Asset.PinBinding,
   gpio_handler: FarmbotCore.PinBindingWorker.StubGPIOHandler,
   error_retry_time_ms: 30_000
 
+config :farmbot_core, Elixir.FarmbotCore.AssetWorker.FarmbotCore.Asset.PublicKey,
+  ssh_handler: FarmbotCore.PublicKeyHandler.StubSSHHandler
+
 config :farmbot_core, FarmbotCore.AssetWorker.FarmbotCore.Asset.FarmwareInstallation,
   error_retry_time_ms: 30_000,
   install_dir: "/tmp/farmware"

--- a/farmbot_ext/lib/farmbot_ext/api/sync_group.ex
+++ b/farmbot_ext/lib/farmbot_ext/api/sync_group.ex
@@ -11,6 +11,7 @@ defmodule FarmbotExt.API.SyncGroup do
     Peripheral,
     PinBinding,
     Point,
+    # PublicKey,
     Regimen,
     SensorReading,
     Sensor,
@@ -28,6 +29,7 @@ defmodule FarmbotExt.API.SyncGroup do
       FirmwareConfig,
       FarmwareEnv,
       FarmwareInstallation
+      # PublicKey
     ]
 
   @doc "Group 1 should have no external requirements"

--- a/farmbot_os/config/config.exs
+++ b/farmbot_os/config/config.exs
@@ -9,6 +9,9 @@ config :farmbot_core, FarmbotCore.AssetWorker.FarmbotCore.Asset.FarmwareInstalla
   error_retry_time_ms: 30_000,
   install_dir: "/tmp/farmware"
 
+config :farmbot_core, Elixir.FarmbotCore.AssetWorker.FarmbotCore.Asset.PublicKey,
+  ssh_handler: FarmbotCore.PublicKeyHandler.StubSSHHandler
+
 config :farmbot_core, FarmbotCore.AssetWorker.FarmbotCore.Asset.PinBinding,
   gpio_handler: FarmbotCore.PinBindingWorker.StubGPIOHandler,
   error_retry_time_ms: 30_000

--- a/farmbot_os/config/target/dev.exs
+++ b/farmbot_os/config/target/dev.exs
@@ -19,6 +19,9 @@ config :shoehorn,
 
 config :tzdata, :autoupdate, :disabled
 
+config :farmbot_core, FarmbotCore.AssetWorker.FarmbotCore.Asset.PublicKey,
+  ssh_handler: FarmbotOS.Platform.Target.SSHConsole
+
 config :farmbot_core, FarmbotCore.AssetWorker.FarmbotCore.Asset.PinBinding,
   gpio_handler: FarmbotOS.Platform.Target.PinBindingWorker.CircuitsGPIOHandler,
   # gpio_handler: FarmbotCore.PinBindingWorker.StubGPIOHandler,

--- a/farmbot_os/config/target/prod.exs
+++ b/farmbot_os/config/target/prod.exs
@@ -19,6 +19,9 @@ config :shoehorn,
 
 config :tzdata, :autoupdate, :disabled
 
+config :farmbot_core, FarmbotCore.AssetWorker.FarmbotCore.Asset.PublicKey,
+  ssh_handler: FarmbotOS.Platform.Target.SSHConsole
+
 config :farmbot_core, FarmbotCore.AssetWorker.FarmbotCore.Asset.PinBinding,
   gpio_handler: FarmbotOS.Platform.Target.PinBindingWorker.CircuitsGPIOHandler,
   # gpio_handler: FarmbotCore.PinBindingWorker.StubGPIOHandler,

--- a/farmbot_os/platform/target/ssh_console.ex
+++ b/farmbot_os/platform/target/ssh_console.ex
@@ -5,6 +5,17 @@ defmodule FarmbotOS.Platform.Target.SSHConsole do
   use GenServer
   import FarmbotCore.Config, only: [get_config_value: 3]
   require FarmbotCore.Logger
+  alias FarmbotCore.Asset.PublicKey
+
+  @behaviour FarmbotCore.Asset.PublicKey
+
+  def ready? do
+    is_pid(GenServer.whereis(__MODULE__))
+  end
+
+  def add_key(%PublicKey{} = public_key) do
+    GenServer.cast(__MODULE__, {:add_key, public_key})
+  end
 
   def start_link(args) do
     GenServer.start_link(__MODULE__, args, name: __MODULE__)
@@ -17,16 +28,35 @@ defmodule FarmbotOS.Platform.Target.SSHConsole do
 
     case start_ssh(port, decoded_authorized_key) do
       {:ok, ssh} ->
-        {:ok, %{ssh: ssh}}
+        send(self(), :checkup)
+        {:ok, %{ssh: ssh, port: port, decoded_authorized_key: decoded_authorized_key}}
 
-      _ ->
-        FarmbotCore.Logger.warn(1, "Could not start SSH.")
+      error ->
+        FarmbotCore.Logger.warn(3, "Could not start SSH: #{inspect(error)}")
         :ignore
     end
   end
 
   def terminate(_, %{ssh: ssh}) do
-    :ssh.stop_daemon(ssh)
+    stop_ssh(ssh)
+  end
+
+  def handle_cast({:add_key, %PublicKey{public_key: authorized_key}}, %{ssh: ssh} = state) do
+    _ = stop_ssh(ssh)
+    decoded_authorized_key = do_decode(authorized_key)
+
+    case start_ssh(state.port, [decoded_authorized_key | state.decoded_authorized_key]) do
+      {:ok, ssh} ->
+        {:noreply, %{state | ssh: ssh}}
+
+      error ->
+        FarmbotCore.Logger.warn(3, "Could not start SSH: #{inspect(error)}")
+        {:noreply, %{state | ssh: nil}}
+    end
+  end
+
+  defp stop_ssh(ssh) do
+    ssh && :ssh.stop_daemon(ssh)
   end
 
   defp start_ssh(port, decoded_authorized_keys) when is_list(decoded_authorized_keys) do


### PR DESCRIPTION
This will aid in debugging devices that are local to a developer, but not connected to a serial console. 