### PR TITLE
Disable OTA flashing firmware for now.

### DIFF
--- a/farmbot_os/platform/target/nerves_hub_client.ex
+++ b/farmbot_os/platform/target/nerves_hub_client.ex
@@ -466,8 +466,8 @@ defmodule FarmbotOS.Platform.Target.NervesHubClient do
   end
 
   def set_firmware_needs_flash() do
-    Config.update_config_value(:bool, "settings", "firmware_needs_flash", true)
-    Config.update_config_value(:bool, "settings", "firmware_needs_open", false)
+    # Config.update_config_value(:bool, "settings", "firmware_needs_flash", true)
+    # Config.update_config_value(:bool, "settings", "firmware_needs_open", false)
     :ok
   end
 


### PR DESCRIPTION
This will need to be revisited later, but a better solution will
probably be to just flash the firmware from the FarmbotFirmware module
instead of doing it blindly every ota.