### PR TITLE
Add new RPC for `toggle_pin`

### DIFF
--- a/farmbot_celery_script/lib/farmbot_celery_script/compiler.ex
+++ b/farmbot_celery_script/lib/farmbot_celery_script/compiler.ex
@@ -799,13 +799,7 @@ defmodule FarmbotCeleryScript.Compiler do
 
   compile :toggle_pin, %{pin_number: pin_number} do
     quote location: :keep do
-      # mode 0 = digital
-      case FarmbotCeleryScript.SysCalls.read_pin(unquote(compile_ast(pin_number)), 0) do
-        0 -> FarmbotCeleryScript.SysCalls.write_pin(unquote(compile_ast(pin_number)), 0, 1)
-        _ -> FarmbotCeleryScript.SysCalls.write_pin(unquote(compile_ast(pin_number)), 0, 0)
-      end
-
-      FarmbotCeleryScript.SysCalls.read_pin(unquote(compile_ast(pin_number)), 0)
+      FarmbotCeleryScript.SysCalls.toggle_pin(unquote(pin_number))
     end
   end
 

--- a/farmbot_celery_script/lib/farmbot_celery_script/sys_calls.ex
+++ b/farmbot_celery_script/lib/farmbot_celery_script/sys_calls.ex
@@ -51,6 +51,7 @@ defmodule FarmbotCeleryScript.SysCalls do
   @callback point(point_type :: String.t(), resource_id) :: number() | error()
   @callback power_off() :: ok_or_error
   @callback read_pin(pin_num :: number(), pin_mode :: number()) :: number | error()
+  @callback toggle_pin(pin_num :: number()) :: ok_or_error
   @callback read_status() :: ok_or_error
   @callback reboot() :: ok_or_error
   @callback resource_update(String.t(), resource_id, map()) :: ok_or_error
@@ -218,6 +219,10 @@ defmodule FarmbotCeleryScript.SysCalls do
 
   def read_pin(sys_calls \\ @sys_calls, pin_num, pin_mode) do
     number_or_error(sys_calls, :read_pin, [pin_num, pin_mode])
+  end
+
+  def toggle_pin(sys_calls \\ @sys_calls, pun_num) do
+    ok_or_error(sys_calls, :toggle_pin, [pun_num])
   end
 
   def read_status(sys_calls \\ @sys_calls) do

--- a/farmbot_celery_script/lib/farmbot_celery_script/sys_calls/stubs.ex
+++ b/farmbot_celery_script/lib/farmbot_celery_script/sys_calls/stubs.ex
@@ -95,6 +95,9 @@ defmodule FarmbotCeleryScript.SysCalls.Stubs do
   def read_pin(pin_num, pin_mode), do: error(:read_pin, [pin_num, pin_mode])
 
   @impl true
+  def toggle_pin(pin_num), do: error(:toggle_pin, [pin_num])
+
+  @impl true
   def read_status(), do: error(:read_status, [])
 
   @impl true

--- a/farmbot_os/lib/farmbot_os/sys_calls.ex
+++ b/farmbot_os/lib/farmbot_os/sys_calls.ex
@@ -7,9 +7,7 @@ defmodule FarmbotOS.SysCalls do
 
   alias FarmbotCore.Asset.{
     BoxLed,
-    Peripheral,
-    Private,
-    Sensor
+    Private
   }
 
   alias FarmbotOS.SysCalls.{
@@ -20,7 +18,8 @@ defmodule FarmbotOS.SysCalls do
     FactoryReset,
     FlashFirmware,
     SendMessage,
-    SetPinIOMode
+    SetPinIOMode,
+    PinControl
   }
 
   alias FarmbotOS.Lua
@@ -63,6 +62,15 @@ defmodule FarmbotOS.SysCalls do
   @impl true
   defdelegate eval_assertion(comment, expression), to: Lua
   defdelegate log_assertion(passed?, type, message), to: Lua
+
+  @impl true
+  defdelegate read_pin(number, mode), to: PinControl
+
+  @impl true
+  defdelegate write_pin(number, mode, value), to: PinControl
+
+  @impl true
+  defdelegate toggle_pin(number), to: PinControl
 
   @impl true
   def log(message) do
@@ -168,231 +176,6 @@ defmodule FarmbotOS.SysCalls do
     axis = assert_axis!(axis)
 
     case FarmbotFirmware.command({:position_write_zero, [axis]}) do
-      :ok ->
-        :ok
-
-      {:error, reason} ->
-        {:error, "Firmware error: #{inspect(reason)}"}
-    end
-  end
-
-  @impl true
-  def read_pin(%Peripheral{pin: _} = data, mode) do
-    do_read_pin(data, mode)
-  end
-
-  def read_pin(%Sensor{pin: pin} = data, mode) do
-    case do_read_pin(data, mode) do
-      {:error, _} = error ->
-        error
-
-      value ->
-        position = get_position()
-
-        params = %{
-          pin: pin,
-          mode: mode,
-          value: value,
-          x: position[:x],
-          y: position[:y],
-          z: position[:z]
-        }
-
-        _ = Asset.new_sensor_reading!(params)
-        value
-    end
-  end
-
-  def read_pin(%BoxLed{}, _mode) do
-    # {:error, "cannot read values of BoxLed"}
-    1
-  end
-
-  def read_pin(pin_number, mode) when is_number(pin_number) do
-    sensor = Asset.get_sensor_by_pin(pin_number)
-    peripheral = Asset.get_peripheral_by_pin(pin_number)
-
-    cond do
-      is_map(sensor) ->
-        read_pin(sensor, mode)
-
-      is_map(peripheral) ->
-        read_pin(peripheral, mode)
-
-      true ->
-        do_read_pin(pin_number, mode)
-    end
-  end
-
-  # digital peripheral
-
-  defp do_read_pin(%Peripheral{pin: pin_number, label: label}, 0) when is_number(pin_number) do
-    case FarmbotFirmware.request({:pin_read, [p: pin_number, m: 0]}) do
-      {:ok, {_, {:report_pin_value, [p: _, v: 1]}}} ->
-        FarmbotCore.Logger.info(2, "The #{label} peripheral value is ON (digital)")
-        1
-
-      {:ok, {_, {:report_pin_value, [p: _, v: 0]}}} ->
-        FarmbotCore.Logger.info(2, "The #{label} peripheral value is OFF (digital)")
-        0
-
-      # Just in case
-      {:ok, {_, {:report_pin_value, [p: _, v: value]}}} ->
-        FarmbotCore.Logger.info(2, "The #{label} peripheral value is #{value} (analog)")
-        value
-
-      {:error, reason} ->
-        {:error, "Firmware error: #{inspect(reason)}"}
-    end
-  end
-
-  # analog peripheral
-
-  defp do_read_pin(%Peripheral{pin: pin_number, label: label}, 1) when is_number(pin_number) do
-    case FarmbotFirmware.request({:pin_read, [p: pin_number, m: 1]}) do
-      {:ok, {_, {:report_pin_value, [p: _, v: value]}}} ->
-        FarmbotCore.Logger.info(2, "The #{label} peripheral value is #{value} (analog)")
-        value
-
-      {:error, reason} ->
-        {:error, "Firmware error: #{inspect(reason)}"}
-    end
-  end
-
-  # digital sensor
-
-  defp do_read_pin(%Sensor{pin: pin_number, label: label}, 0) when is_number(pin_number) do
-    case FarmbotFirmware.request({:pin_read, [p: pin_number, m: 0]}) do
-      {:ok, {_, {:report_pin_value, [p: _, v: 1]}}} ->
-        FarmbotCore.Logger.info(2, "The #{label} sensor value is 1 (digital)")
-        1
-
-      {:ok, {_, {:report_pin_value, [p: _, v: 0]}}} ->
-        FarmbotCore.Logger.info(2, "The #{label} sensor value is 0 (digital)")
-        0
-
-      {:ok, {_, {:report_pin_value, [p: _, v: value]}}} ->
-        FarmbotCore.Logger.info(2, "The #{label} sensor value is #{value} (analog)")
-
-      {:error, reason} ->
-        {:error, "Firmware error: #{inspect(reason)}"}
-    end
-  end
-
-  # analog sensor
-
-  defp do_read_pin(%Sensor{pin: pin_number, label: label}, 1) when is_number(pin_number) do
-    case FarmbotFirmware.request({:pin_read, [p: pin_number, m: 1]}) do
-      {:ok, {_, {:report_pin_value, [p: _, v: value]}}} ->
-        FarmbotCore.Logger.info(2, "The #{label} sensor value is #{value} (analog)")
-        value
-
-      {:error, reason} ->
-        {:error, "Firmware error: #{inspect(reason)}"}
-    end
-  end
-
-  # Generic pin digital
-  defp do_read_pin(pin_number, 0) when is_number(pin_number) do
-    case FarmbotFirmware.request({:pin_read, [p: pin_number, m: 0]}) do
-      {:ok, {_, {:report_pin_value, [p: _, v: 0]}}} ->
-        FarmbotCore.Logger.info(2, "Pin #{pin_number} value is OFF (digital)")
-        0
-
-      {:ok, {_, {:report_pin_value, [p: _, v: 1]}}} ->
-        FarmbotCore.Logger.info(2, "Pin #{pin_number} value is ON (digital)")
-        1
-
-      {:ok, {_, {:report_pin_value, [p: _, v: value]}}} ->
-        FarmbotCore.Logger.info(2, "Pin #{pin_number} is #{value} (analog)")
-        value
-
-      {:error, reason} ->
-        {:error, "Firmware error: #{inspect(reason)}"}
-    end
-  end
-
-  # Generic pin digital
-  defp do_read_pin(pin_number, 1) when is_number(pin_number) do
-    case FarmbotFirmware.request({:pin_read, [p: pin_number, m: 1]}) do
-      {:ok, {_, {:report_pin_value, [p: _, v: value]}}} ->
-        FarmbotCore.Logger.info(2, "Pin #{pin_number} is #{value} (analog)")
-        value
-
-      {:error, reason} ->
-        {:error, "Firmware error: #{inspect(reason)}"}
-    end
-  end
-
-  @impl true
-
-  # Peripheral digital
-  def write_pin(%Peripheral{pin: pin, label: label}, 0, 1) do
-    FarmbotCore.Logger.info(2, "Turning the #{label} ON (digital)")
-    do_write_pin(pin, 0, 1)
-  end
-
-  def write_pin(%Peripheral{pin: pin, label: label}, 0, 0) do
-    FarmbotCore.Logger.info(2, "Turning the #{label} OFF (digital)")
-    do_write_pin(pin, 0, 0)
-  end
-
-  # Peripheral analog
-  def write_pin(%Peripheral{pin: pin, label: label}, 1, value) do
-    FarmbotCore.Logger.info(2, "Setting the #{label} to #{value} (analog)")
-    do_write_pin(pin, 0, 0)
-  end
-
-  def write_pin(%Sensor{pin: _pin}, _mode, _value) do
-    {:error, "cannot write Sensor value. Use a Peripheral"}
-  end
-
-  def write_pin(%BoxLed{id: 3}, 0, 1) do
-    FarmbotCore.Logger.info(2, "Turning Boxled3 ON")
-    Leds.white4(:solid)
-    :ok
-  end
-
-  def write_pin(%BoxLed{id: 3}, 0, 0) do
-    FarmbotCore.Logger.info(2, "Turning Boxled3 OFF")
-    Leds.white4(:off)
-    :ok
-  end
-
-  def write_pin(%BoxLed{id: 4}, 0, 1) do
-    FarmbotCore.Logger.info(2, "Turning Boxled4 ON")
-    Leds.white5(:solid)
-    :ok
-  end
-
-  def write_pin(%BoxLed{id: 4}, 0, 0) do
-    FarmbotCore.Logger.info(2, "Turning Boxled4 OFF")
-    Leds.white5(:off)
-    :ok
-  end
-
-  def write_pin(%BoxLed{id: id}, _mode, _) do
-    {:error, "cannon write Boxled#{id} in analog mode"}
-  end
-
-  # Generic pin digital
-  def write_pin(pin, 0, 1) do
-    FarmbotCore.Logger.info(2, "Turning pin #{pin} ON (digital)")
-    do_write_pin(pin, 0, 1)
-  end
-
-  def write_pin(pin, 0, 0) do
-    FarmbotCore.Logger.info(2, "Turning pin #{pin} OFF (digital)")
-    do_write_pin(pin, 0, 0)
-  end
-
-  def write_pin(pin, 1, value) do
-    FarmbotCore.Logger.info(2, "Setting pin #{pin} to #{value} (analog)")
-    do_write_pin(pin, 1, value)
-  end
-
-  def do_write_pin(pin_number, mode, value) do
-    case FarmbotFirmware.command({:pin_write, [p: pin_number, v: value, m: mode]}) do
       :ok ->
         :ok
 

--- a/farmbot_os/lib/farmbot_os/sys_calls/pin_control.ex
+++ b/farmbot_os/lib/farmbot_os/sys_calls/pin_control.ex
@@ -1,0 +1,257 @@
+defmodule FarmbotOS.SysCalls.PinControl do
+  alias FarmbotCore.{Asset, Leds}
+
+  alias FarmbotCore.Asset.{
+    BoxLed,
+    Peripheral,
+    Sensor
+  }
+
+  require FarmbotCore.Logger
+
+  def toggle_pin(pin_number) when is_number(pin_number) do
+    case FarmbotFirmware.request({:pin_read, [p: pin_number, m: 0]}) do
+      {:ok, {_, {:report_pin_value, [p: _, v: 1]}}} ->
+        do_toggle_pin(pin_number, 0)
+
+      {:ok, {_, {:report_pin_value, [p: _, v: 0]}}} ->
+        do_toggle_pin(pin_number, 1)
+    end
+  end
+
+  def toggle_pin(pin_number) do
+    {:error, "Unknown pin data: #{inspect(pin_number)}"}
+  end
+
+  defp do_toggle_pin(pin_number, value) do
+    with :ok <- FarmbotFirmware.command({:pin_write, [p: pin_number, v: value, m: 0]}),
+         value when is_number(value) <- do_read_pin(pin_number, 0) do
+      :ok
+    else
+      {:error, reason} ->
+        {:error, "Firmware error: #{inspect(reason)}"}
+    end
+  end
+
+  def read_pin(%Peripheral{pin: _} = data, mode) do
+    do_read_pin(data, mode)
+  end
+
+  def read_pin(%Sensor{pin: pin} = data, mode) do
+    case do_read_pin(data, mode) do
+      {:error, _} = error ->
+        error
+
+      value ->
+        position = FarmbotOS.SysCalls.get_position()
+
+        params = %{
+          pin: pin,
+          mode: mode,
+          value: value,
+          x: position[:x],
+          y: position[:y],
+          z: position[:z]
+        }
+
+        _ = Asset.new_sensor_reading!(params)
+        value
+    end
+  end
+
+  def read_pin(%BoxLed{}, _mode) do
+    # {:error, "cannot read values of BoxLed"}
+    1
+  end
+
+  def read_pin(pin_number, mode) when is_number(pin_number) do
+    sensor = Asset.get_sensor_by_pin(pin_number)
+    peripheral = Asset.get_peripheral_by_pin(pin_number)
+
+    cond do
+      is_map(sensor) ->
+        read_pin(sensor, mode)
+
+      is_map(peripheral) ->
+        read_pin(peripheral, mode)
+
+      true ->
+        do_read_pin(pin_number, mode)
+    end
+  end
+
+  # digital peripheral
+
+  defp do_read_pin(%Peripheral{pin: pin_number, label: label}, 0) when is_number(pin_number) do
+    case FarmbotFirmware.request({:pin_read, [p: pin_number, m: 0]}) do
+      {:ok, {_, {:report_pin_value, [p: _, v: 1]}}} ->
+        FarmbotCore.Logger.info(2, "The #{label} peripheral value is ON (digital)")
+        1
+
+      {:ok, {_, {:report_pin_value, [p: _, v: 0]}}} ->
+        FarmbotCore.Logger.info(2, "The #{label} peripheral value is OFF (digital)")
+        0
+
+      # Just in case
+      {:ok, {_, {:report_pin_value, [p: _, v: value]}}} ->
+        FarmbotCore.Logger.info(2, "The #{label} peripheral value is #{value} (analog)")
+        value
+
+      {:error, reason} ->
+        {:error, "Firmware error: #{inspect(reason)}"}
+    end
+  end
+
+  # analog peripheral
+
+  defp do_read_pin(%Peripheral{pin: pin_number, label: label}, 1) when is_number(pin_number) do
+    case FarmbotFirmware.request({:pin_read, [p: pin_number, m: 1]}) do
+      {:ok, {_, {:report_pin_value, [p: _, v: value]}}} ->
+        FarmbotCore.Logger.info(2, "The #{label} peripheral value is #{value} (analog)")
+        value
+
+      {:error, reason} ->
+        {:error, "Firmware error: #{inspect(reason)}"}
+    end
+  end
+
+  # digital sensor
+
+  defp do_read_pin(%Sensor{pin: pin_number, label: label}, 0) when is_number(pin_number) do
+    case FarmbotFirmware.request({:pin_read, [p: pin_number, m: 0]}) do
+      {:ok, {_, {:report_pin_value, [p: _, v: 1]}}} ->
+        FarmbotCore.Logger.info(2, "The #{label} sensor value is 1 (digital)")
+        1
+
+      {:ok, {_, {:report_pin_value, [p: _, v: 0]}}} ->
+        FarmbotCore.Logger.info(2, "The #{label} sensor value is 0 (digital)")
+        0
+
+      {:ok, {_, {:report_pin_value, [p: _, v: value]}}} ->
+        FarmbotCore.Logger.info(2, "The #{label} sensor value is #{value} (analog)")
+
+      {:error, reason} ->
+        {:error, "Firmware error: #{inspect(reason)}"}
+    end
+  end
+
+  # analog sensor
+
+  defp do_read_pin(%Sensor{pin: pin_number, label: label}, 1) when is_number(pin_number) do
+    case FarmbotFirmware.request({:pin_read, [p: pin_number, m: 1]}) do
+      {:ok, {_, {:report_pin_value, [p: _, v: value]}}} ->
+        FarmbotCore.Logger.info(2, "The #{label} sensor value is #{value} (analog)")
+        value
+
+      {:error, reason} ->
+        {:error, "Firmware error: #{inspect(reason)}"}
+    end
+  end
+
+  # Generic pin digital
+  defp do_read_pin(pin_number, 0) when is_number(pin_number) do
+    case FarmbotFirmware.request({:pin_read, [p: pin_number, m: 0]}) do
+      {:ok, {_, {:report_pin_value, [p: _, v: 0]}}} ->
+        FarmbotCore.Logger.info(2, "Pin #{pin_number} value is OFF (digital)")
+        0
+
+      {:ok, {_, {:report_pin_value, [p: _, v: 1]}}} ->
+        FarmbotCore.Logger.info(2, "Pin #{pin_number} value is ON (digital)")
+        1
+
+      {:ok, {_, {:report_pin_value, [p: _, v: value]}}} ->
+        FarmbotCore.Logger.info(2, "Pin #{pin_number} is #{value} (analog)")
+        value
+
+      {:error, reason} ->
+        {:error, "Firmware error: #{inspect(reason)}"}
+    end
+  end
+
+  # Generic pin digital
+  defp do_read_pin(pin_number, 1) when is_number(pin_number) do
+    case FarmbotFirmware.request({:pin_read, [p: pin_number, m: 1]}) do
+      {:ok, {_, {:report_pin_value, [p: _, v: value]}}} ->
+        FarmbotCore.Logger.info(2, "Pin #{pin_number} is #{value} (analog)")
+        value
+
+      {:error, reason} ->
+        {:error, "Firmware error: #{inspect(reason)}"}
+    end
+  end
+
+  # Peripheral digital
+  def write_pin(%Peripheral{pin: pin, label: label}, 0, 1) do
+    FarmbotCore.Logger.info(2, "Turning the #{label} ON (digital)")
+    do_write_pin(pin, 0, 1)
+  end
+
+  def write_pin(%Peripheral{pin: pin, label: label}, 0, 0) do
+    FarmbotCore.Logger.info(2, "Turning the #{label} OFF (digital)")
+    do_write_pin(pin, 0, 0)
+  end
+
+  # Peripheral analog
+  def write_pin(%Peripheral{pin: pin, label: label}, 1, value) do
+    FarmbotCore.Logger.info(2, "Setting the #{label} to #{value} (analog)")
+    do_write_pin(pin, 0, 0)
+  end
+
+  def write_pin(%Sensor{pin: _pin}, _mode, _value) do
+    {:error, "cannot write Sensor value. Use a Peripheral"}
+  end
+
+  def write_pin(%BoxLed{id: 3}, 0, 1) do
+    FarmbotCore.Logger.info(2, "Turning Boxled3 ON")
+    Leds.white4(:solid)
+    :ok
+  end
+
+  def write_pin(%BoxLed{id: 3}, 0, 0) do
+    FarmbotCore.Logger.info(2, "Turning Boxled3 OFF")
+    Leds.white4(:off)
+    :ok
+  end
+
+  def write_pin(%BoxLed{id: 4}, 0, 1) do
+    FarmbotCore.Logger.info(2, "Turning Boxled4 ON")
+    Leds.white5(:solid)
+    :ok
+  end
+
+  def write_pin(%BoxLed{id: 4}, 0, 0) do
+    FarmbotCore.Logger.info(2, "Turning Boxled4 OFF")
+    Leds.white5(:off)
+    :ok
+  end
+
+  def write_pin(%BoxLed{id: id}, _mode, _) do
+    {:error, "cannon write Boxled#{id} in analog mode"}
+  end
+
+  # Generic pin digital
+  def write_pin(pin, 0, 1) do
+    FarmbotCore.Logger.info(2, "Turning pin #{pin} ON (digital)")
+    do_write_pin(pin, 0, 1)
+  end
+
+  def write_pin(pin, 0, 0) do
+    FarmbotCore.Logger.info(2, "Turning pin #{pin} OFF (digital)")
+    do_write_pin(pin, 0, 0)
+  end
+
+  def write_pin(pin, 1, value) do
+    FarmbotCore.Logger.info(2, "Setting pin #{pin} to #{value} (analog)")
+    do_write_pin(pin, 1, value)
+  end
+
+  def do_write_pin(pin_number, mode, value) do
+    case FarmbotFirmware.command({:pin_write, [p: pin_number, v: value, m: mode]}) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        {:error, "Firmware error: #{inspect(reason)}"}
+    end
+  end
+end

--- a/test/support/celery_script/test_sys_calls.ex
+++ b/test/support/celery_script/test_sys_calls.ex
@@ -122,6 +122,11 @@ defmodule Farmbot.TestSupport.CeleryScript.TestSysCalls do
   end
 
   @impl true
+  def toggle_pin(number) do
+    call({:toggle_pin, [number]})
+  end
+
+  @impl true
   def wait(millis) do
     call({:wait, [millis]})
   end


### PR DESCRIPTION
This was previously implemented as a "macro" that just expanded
`toggle_pin` to a series of `read_pin` -> `write_pin` -> `read_pin` this
lead to three logs instead of just one. The implementation is still
mostly the same, but now there is less logging.

Also factored all pin control into it's own module