### PR TITLE
Fix CeleryScript channel not reconnecting even more

### DIFF
--- a/farmbot_ext/lib/farmbot_ext/amqp/celery_script_channel.ex
+++ b/farmbot_ext/lib/farmbot_ext/amqp/celery_script_channel.ex
@@ -26,7 +26,8 @@ defmodule FarmbotExt.AMQP.CeleryScriptChannel do
   def init(args) do
     jwt = Keyword.fetch!(args, :jwt)
     Process.flag(:sensitive, true)
-    {:ok, %State{conn: nil, chan: nil, jwt: jwt, rpc_requests: %{}}, 0}
+    send(self(), :timeout)
+    {:ok, %State{conn: nil, chan: nil, jwt: jwt, rpc_requests: %{}}}
   end
 
   def terminate(reason, state) do

--- a/farmbot_ext/lib/farmbot_ext/amqp/connection_worker.ex
+++ b/farmbot_ext/lib/farmbot_ext/amqp/connection_worker.ex
@@ -64,6 +64,8 @@ defmodule FarmbotExt.AMQP.ConnectionWorker do
          {:ok, _} <- maybe_purge(chan, chan_name, purge?),
          :ok <- Queue.bind(chan, chan_name, @exchange, routing_key: route),
          {:ok, _} <- Basic.consume(chan, chan_name, self(), no_ack: true) do
+      Process.link(conn.pid)
+      Process.link(chan.pid)
       %{conn: conn, chan: chan}
     else
       nil -> %{conn: nil, chan: nil}


### PR DESCRIPTION
This is an addition to #948 that supports network errors causing a disconnect.