### PR TITLE
Address issues with scheduler effort reporting; fixes for Issue 1040

### DIFF
--- a/farmbot_core/lib/farmbot_core/bot_state/scheduler_usage_reporter.ex
+++ b/farmbot_core/lib/farmbot_core/bot_state/scheduler_usage_reporter.ex
@@ -3,43 +3,47 @@ defmodule FarmbotCore.BotState.SchedulerUsageReporter do
   require FarmbotTelemetry
   use GenServer
   @default_timeout_ms 5000
+  @schedulers [:scheduler, :dirty_cpu_scheduler]
 
   def start_link(args) do
     GenServer.start_link(__MODULE__, args)
   end
 
   def init(_args) do
+    _ = :msacc.stop()
+    _ = :msacc.reset()
     _ = :msacc.start()
     {:ok, %{}, @default_timeout_ms}
   end
 
   def handle_info(:timeout, state) do
-    scheduler_info = for %{
-      type: type,
-      id: id,
-      counters: %{
-        aux: aux,
-        check_io: check_io,
-        emulator: emulator,
-        gc: gc,
-        other: other,
-        port: port,
-        sleep: sleep
-      }
-    } when type in [:scheduler, :dirty_cpu_scheduler] <- :msacc.stats() do
-      denominator = aux + check_io + emulator + gc + other + port + sleep
-      numerator = denominator - sleep
-      {"#{type}_#{id}", numerator / denominator}
-    end
+    scheduler_info =
+      for %{
+            type: type,
+            counters: %{
+              aux: aux,
+              check_io: check_io,
+              emulator: emulator,
+              gc: gc,
+              other: other,
+              port: port,
+              sleep: sleep
+            }
+          }
+          when type in @schedulers <- :msacc.stats(:type, :msacc.stats()) do
+        denominator = aux + check_io + emulator + gc + other + port + sleep
+        numerator = denominator - sleep
+        {"#{type}", numerator / denominator}
+      end
 
-    average = calculate_average(scheduler_info, Enum.count(scheduler_info))
-    _ = BotState.report_scheduler_usage(average)
+    sched_effort =
+      Enum.map_reduce(scheduler_info, 0, fn sched_info, acc ->
+        work = elem(sched_info, 1)
+        {work, work + acc}
+      end)
+
+    _ = BotState.report_scheduler_usage(round(elem(sched_effort, 1) / length(@schedulers) * 100))
+    _ = :msacc.reset()
     {:noreply, state, @default_timeout_ms}
   end
-
-  defp calculate_average(usage, count, acc \\ 0)
-  defp calculate_average([{_, usage} | rest], count, acc), 
-    do: calculate_average(rest, count, acc + usage)
-  defp calculate_average([], count, acc), 
-    do: round((acc / count) * 100)
 end


### PR DESCRIPTION
Three main changes

- **`:msacc.reset()`** in **`init`** ( otherwise, seriously large `sleep` values are used which swamp everything )
- Let **`:msacc.stats(:type, ...)`** aggregate the per-core scheduler counters
- So that the summary value sent to FrontEnd reflects Scheduler effort for just the past 5 second period, use **`:msacc.reset()`** every cycle.
