### PR TITLE
resource_update enhancements

### DIFF
--- a/farmbot_core/lib/farmbot_core/asset/device.ex
+++ b/farmbot_core/lib/farmbot_core/asset/device.ex
@@ -20,6 +20,7 @@ defmodule FarmbotCore.Asset.Device do
     field(:last_ota, :utc_datetime)
     field(:last_ota_checkup, :utc_datetime)
     field(:ota_hour, :integer)
+    field(:mounted_tool_id, :integer)
     field(:monitor, :boolean, default: true)
     timestamps()
   end
@@ -31,7 +32,8 @@ defmodule FarmbotCore.Asset.Device do
       timezone: device.timezone,
       last_ota: device.last_ota,
       last_ota_checkup: device.last_ota_checkup,
-      ota_hour: device.ota_hour
+      ota_hour: device.ota_hour,
+      mounted_tool_id: device.mounted_tool_id
     }
   end
 
@@ -43,6 +45,7 @@ defmodule FarmbotCore.Asset.Device do
       :last_ota, 
       :last_ota_checkup, 
       :ota_hour,
+      :mounted_tool_id,
       :monitor, 
       :created_at, 
       :updated_at

--- a/farmbot_core/priv/asset/migrations/20191122185123_add_mounted_tool_id_to_device_table.exs
+++ b/farmbot_core/priv/asset/migrations/20191122185123_add_mounted_tool_id_to_device_table.exs
@@ -1,0 +1,9 @@
+defmodule FarmbotCore.Asset.Repo.Migrations.AddMountedToolIdToDeviceTable do
+  use Ecto.Migration
+
+  def change do
+    alter table(:devices) do
+      add(:mounted_tool_id, :integer)
+    end
+  end
+end

--- a/farmbot_core/priv/asset/migrations/20191122185220_force_resync_device_for_mounted_tool_id.exs
+++ b/farmbot_core/priv/asset/migrations/20191122185220_force_resync_device_for_mounted_tool_id.exs
@@ -1,4 +1,4 @@
-defmodule FarmbotCore.Asset.Repo.Migrations.ForceResyncDevice do
+defmodule FarmbotCore.Asset.Repo.Migrations.ForceResyncDeviceForMountedToolId do
   use Ecto.Migration
   alias FarmbotCore.Asset.{Repo, Device}
 


### PR DESCRIPTION
Fixes #1067

this adds the ability to update `GenericPointer`s from `resource_update` and adds the `mounted_tool_id` field to the `Device` table, allowing it to be updated from the `resource_update` rpc