### PR TITLE
Fix firmware_debug_logs and arduino_debug_messages being ignored

### DIFF
--- a/farmbot_core/lib/farmbot_core/asset_workers/fbos_config_worker.ex
+++ b/farmbot_core/lib/farmbot_core/asset_workers/fbos_config_worker.ex
@@ -184,6 +184,7 @@ defimpl FarmbotCore.AssetWorker, for: FarmbotCore.Asset.FbosConfig do
       :arduino_debug_messages,
       :firmware_input_log,
       :firmware_output_log,
+      :firmware_debug_log,
       :auto_sync,
       :beta_opt_in,
       :disable_factory_reset,
@@ -206,6 +207,9 @@ defimpl FarmbotCore.AssetWorker, for: FarmbotCore.Asset.FbosConfig do
 
       {:firmware_output_log, bool} ->
         FarmbotCore.Logger.success 1, "Set arduino output logs to #{bool}"
+
+      {:firmware_debug_log, bool} ->
+        FarmbotCore.Logger.success 1, "Set arduino debug messages to #{bool}"
 
       {:auto_sync, bool} ->
         FarmbotCore.Logger.success 1, "Set auto sync to #{bool}"
@@ -248,6 +252,8 @@ defimpl FarmbotCore.AssetWorker, for: FarmbotCore.Asset.FbosConfig do
     :ok = BotState.set_config_value(:arduino_debug_messages, fbos_config.arduino_debug_messages)
     :ok = BotState.set_config_value(:firmware_input_log, fbos_config.firmware_input_log)
     :ok = BotState.set_config_value(:firmware_output_log, fbos_config.firmware_output_log)
+    :ok = BotState.set_config_value(:firmware_debug_log, fbos_config.firmware_debug_log)
+
     # firmware_hardware is set by FarmbotFirmware.SideEffects
 
     :ok = BotState.set_config_value(:auto_sync, fbos_config.auto_sync)

--- a/farmbot_core/lib/farmbot_core/bot_state_ng/configuration.ex
+++ b/farmbot_core/lib/farmbot_core/bot_state_ng/configuration.ex
@@ -14,6 +14,7 @@ defmodule FarmbotCore.BotStateNG.Configuration do
     field(:firmware_hardware, :string)
     field(:firmware_input_log, :boolean)
     field(:firmware_output_log, :boolean)
+    field(:firmware_debug_log, :boolean)
     field(:network_not_found_timer, :integer)
     field(:os_auto_update, :boolean)
     field(:sequence_body_log, :boolean)
@@ -36,6 +37,7 @@ defmodule FarmbotCore.BotStateNG.Configuration do
       firmware_hardware: configuration.firmware_hardware,
       firmware_input_log: configuration.firmware_input_log,
       firmware_output_log: configuration.firmware_output_log,
+      firmware_debug_log: configuration.firmware_debug_log,
       network_not_found_timer: configuration.network_not_found_timer,
       os_auto_update: configuration.os_auto_update,
       sequence_body_log: configuration.sequence_body_log,
@@ -54,6 +56,7 @@ defmodule FarmbotCore.BotStateNG.Configuration do
       :firmware_hardware,
       :firmware_input_log,
       :firmware_output_log,
+      :firmware_debug_log,
       :network_not_found_timer,
       :os_auto_update,
       :sequence_body_log,

--- a/farmbot_core/lib/farmbot_core/firmware_side_effects.ex
+++ b/farmbot_core/lib/farmbot_core/firmware_side_effects.ex
@@ -149,7 +149,8 @@ defmodule FarmbotCore.FirmwareSideEffects do
 
   @impl FarmbotFirmware.SideEffects
   def handle_debug_message([message]) do
-    should_log? = Asset.fbos_config().firmware_debug_log
+    fbos_config = Asset.fbos_config()
+    should_log? = fbos_config.firmware_debug_log || fbos_config.arduino_debug_messages 
     should_log? && FarmbotCore.Logger.debug(3, "Firmware debug message: " <> message)
   end
 


### PR DESCRIPTION
Don't know which of these params is supposed to be used for this
feature, so added both of them.

Fixes #1056