### PR TITLE
Ability to Factory Reset when AMQP is down

### DIFF
--- a/farmbot_celery_script/lib/farmbot_celery_script/ast/factory.ex
+++ b/farmbot_celery_script/lib/farmbot_celery_script/ast/factory.ex
@@ -75,4 +75,9 @@ defmodule FarmbotCeleryScript.AST.Factory do
   def add_body_node(%AST{body: body} = ast, %AST{} = body_node) do
     %{ast | body: body ++ [body_node]}
   end
+
+  def factory_reset(%AST{} = ast, package) do
+    ast
+    |> add_body_node(new(:factory_reset, %{package: package}))
+  end
 end

--- a/farmbot_core/lib/farmbot_core/asset/device.ex
+++ b/farmbot_core/lib/farmbot_core/asset/device.ex
@@ -22,6 +22,7 @@ defmodule FarmbotCore.Asset.Device do
     field(:ota_hour, :integer)
     field(:mounted_tool_id, :integer)
     field(:monitor, :boolean, default: true)
+    field(:needs_reset, :boolean, default: false)
     timestamps()
   end
 
@@ -33,22 +34,25 @@ defmodule FarmbotCore.Asset.Device do
       last_ota: device.last_ota,
       last_ota_checkup: device.last_ota_checkup,
       ota_hour: device.ota_hour,
+      needs_reset: device.needs_reset,
       mounted_tool_id: device.mounted_tool_id
     }
   end
 
   def changeset(device, params \\ %{}) do
     device
-    |> cast(params, [:id, 
-      :name, 
-      :timezone, 
-      :last_ota, 
-      :last_ota_checkup, 
+    |> cast(params, [
+      :id,
+      :name,
+      :timezone,
+      :last_ota,
+      :last_ota_checkup,
       :ota_hour,
       :mounted_tool_id,
-      :monitor, 
-      :created_at, 
-      :updated_at
+      :monitor,
+      :created_at,
+      :updated_at,
+      :needs_reset
     ])
     |> validate_required([])
   end

--- a/farmbot_core/lib/farmbot_core/asset_workers/device_worker.ex
+++ b/farmbot_core/lib/farmbot_core/asset_workers/device_worker.ex
@@ -27,18 +27,16 @@ defimpl FarmbotCore.AssetWorker, for: FarmbotCore.Asset.Device do
       |> AST.Factory.rpc_request("RESET_DEVICE_NOW")
       |> AST.Factory.factory_reset("farmbot_os")
 
-    case FarmbotCeleryScript.execute(ast, make_ref()) do
-      :ok ->
-        :ok
-
-      {:error, reason} ->
-        FarmbotCore.Logger.error(1, "error executing #{state.pin_binding}: #{reason}")
-    end
+    :ok = FarmbotCeleryScript.execute(ast, make_ref())
 
     {:noreply, state}
   end
 
   def handle_info(:check_factory_reset, state) do
+    {:noreply, state}
+  end
+
+  def handle_info({:step_complete, _ref, _}, state) do
     {:noreply, state}
   end
 

--- a/farmbot_core/priv/asset/migrations/20191219192107_add_needs_reset_to_device.exs
+++ b/farmbot_core/priv/asset/migrations/20191219192107_add_needs_reset_to_device.exs
@@ -1,0 +1,12 @@
+defmodule FarmbotCore.Asset.Repo.Migrations.AddNeedsResetToDevice do
+  use Ecto.Migration
+
+  def change do
+    alter table("devices") do
+      add(:needs_reset, :boolean, default: false)
+    end
+
+    # Invalidate cache of local device resource:
+    execute("UPDATE devices SET updated_at = \"1970-11-07 16:52:31.618000\"")
+  end
+end

--- a/farmbot_core/test/asset_workers/device_worker_test.exs
+++ b/farmbot_core/test/asset_workers/device_worker_test.exs
@@ -5,12 +5,17 @@ defmodule FarmbotCore.DeviceWorkerTest do
   alias FarmbotCore.AssetWorker
   alias Farmbot.TestSupport.CeleryScript.TestSysCalls
 
+  def fresh_device(needs_reset \\ true) do
+    params = %{needs_reset: needs_reset}
+    assert %Device{} = dev = AssetFixtures.device_init(params)
+    dev
+  end
+
   describe "devices" do
-    test "updates device triggering " do
+    test "triggering of factory reset during init" do
       {:ok, _} = TestSysCalls.checkout()
       test_pid = self()
-      params = %{needs_reset: true}
-      assert %Device{} = dev = AssetFixtures.device(params)
+      dev = fresh_device()
 
       :ok =
         TestSysCalls.handle(TestSysCalls, fn
@@ -22,5 +27,24 @@ defmodule FarmbotCore.DeviceWorkerTest do
       {:ok, _pid} = AssetWorker.start_link(dev, [])
       assert_receive {:factory_reset, ["farmbot_os"]}
     end
+  end
+
+  test "triggering of factory reset during update" do
+    {:ok, _} = TestSysCalls.checkout()
+    test_pid = self()
+    dev = fresh_device(false)
+
+    :ok =
+      TestSysCalls.handle(TestSysCalls, fn
+        kind, args ->
+          send(test_pid, {kind, args})
+          :ok
+      end)
+
+    {:ok, pid} = AssetWorker.start_link(dev, [])
+    refute_receive {:factory_reset, ["farmbot_os"]}
+
+    GenServer.cast(pid, {:new_data, %{dev | needs_reset: true}})
+    assert_receive {:factory_reset, ["farmbot_os"]}
   end
 end

--- a/farmbot_core/test/asset_workers/device_worker_test.exs
+++ b/farmbot_core/test/asset_workers/device_worker_test.exs
@@ -1,0 +1,26 @@
+defmodule FarmbotCore.DeviceWorkerTest do
+  use ExUnit.Case, async: false
+  alias Farmbot.TestSupport.AssetFixtures
+  alias FarmbotCore.Asset.Device
+  alias FarmbotCore.AssetWorker
+  alias Farmbot.TestSupport.CeleryScript.TestSysCalls
+
+  describe "devices" do
+    test "updates device triggering " do
+      {:ok, _} = TestSysCalls.checkout()
+      test_pid = self()
+      params = %{needs_reset: true}
+      assert %Device{} = dev = AssetFixtures.device(params)
+
+      :ok =
+        TestSysCalls.handle(TestSysCalls, fn
+          kind, args ->
+            send(test_pid, {kind, args})
+            :ok
+        end)
+
+      {:ok, _pid} = AssetWorker.start_link(dev, [])
+      assert_receive {:factory_reset, ["farmbot_os"]}
+    end
+  end
+end

--- a/farmbot_os/lib/farmbot_os/sys_calls/factory_reset.ex
+++ b/farmbot_os/lib/farmbot_os/sys_calls/factory_reset.ex
@@ -5,6 +5,7 @@ defmodule FarmbotOS.SysCalls.FactoryReset do
   alias FarmbotExt.API
 
   def factory_reset("farmbot_os") do
+    _ = API.put!(API.client(), "/api/device", %{needs_reset: false})
     FarmbotOS.System.factory_reset("Factory reset requested by Sequence or frontend", true)
     :ok
   end

--- a/test/support/asset_fixtures.ex
+++ b/test/support/asset_fixtures.ex
@@ -101,7 +101,10 @@ defmodule Farmbot.TestSupport.AssetFixtures do
     |> Repo.insert!()
   end
 
-  def device(params \\ %{}) do
+  @doc """
+  Instantiates, but does not create, a %Device{}
+  """
+  def device_init(params \\ %{}) do
     defaults = %{id: :rand.uniform(1_000_000), monitor: false}
     params = Map.merge(defaults, params)
 

--- a/test/support/asset_fixtures.ex
+++ b/test/support/asset_fixtures.ex
@@ -1,6 +1,14 @@
 defmodule Farmbot.TestSupport.AssetFixtures do
   alias FarmbotCore.Asset
-  alias FarmbotCore.Asset.{Repo, FarmEvent, FbosConfig, Regimen, Sequence}
+
+  alias FarmbotCore.Asset.{
+    Device,
+    FarmEvent,
+    FbosConfig,
+    Regimen,
+    Repo,
+    Sequence
+  }
 
   def regimen_instance(regimen_params, farm_event_params, params \\ %{}) do
     regimen = regimen(regimen_params)
@@ -91,5 +99,15 @@ defmodule Farmbot.TestSupport.AssetFixtures do
     |> struct()
     |> FarmEvent.changeset(params)
     |> Repo.insert!()
+  end
+
+  def device(params \\ %{}) do
+    defaults = %{id: :rand.uniform(1_000_000), monitor: false}
+    params = Map.merge(defaults, params)
+
+    Device
+    |> struct()
+    |> Device.changeset(params)
+    |> Ecto.Changeset.apply_changes()
   end
 end


### PR DESCRIPTION
# What's New?

 * Add a new `needs_reset` field to the device table so that you can reset your device even if AMQP is unreachable.

# What's Next?

 * Add stuff to the API side and do a recovery deploy.
