### PR TITLE
Return rpc_ok with label from original RPC request

### DIFF
--- a/farmbot_core/lib/farmbot_core/farmware_runtime.ex
+++ b/farmbot_core/lib/farmbot_core/farmware_runtime.ex
@@ -154,8 +154,7 @@ defmodule FarmbotCore.FarmwareRuntime do
   end
 
   def handle_info({:step_complete, ref, :ok}, %{scheduler_ref: ref} = state) do
-    label = UUID.uuid4()
-    result = %AST{kind: :rpc_ok, args: %{label: label}, body: []}
+    result = %AST{kind: :rpc_ok, args: %{label: state.rpc.args.label}, body: []}
 
     ipc = add_header(result)
     _reply = PipeWorker.write(state.response_pipe_handle, ipc)


### PR DESCRIPTION
Fixes [this post in FarmBot Forum](https://forum.farmbot.org/t/farmware-moveabsolute-and-executesequence-not-working/5784/40).
