### PR TITLE
Increase farmware time limit to 60s from 30s

### DIFF
--- a/farmbot_os/lib/farmbot_os/sys_calls/farmware.ex
+++ b/farmbot_os/lib/farmbot_os/sys_calls/farmware.ex
@@ -4,7 +4,7 @@ defmodule FarmbotOS.SysCalls.Farmware do
   require FarmbotCore.Logger
   alias FarmbotCore.{Asset, AssetSupervisor, FarmwareRuntime}
   alias FarmbotExt.API.ImageUploader
-  @farmware_timeout 30_000
+  @farmware_timeout 60_000
 
   def update_farmware(farmware_name) do
     with {:ok, installation} <- lookup_installation(farmware_name) do

--- a/farmbot_os/test/farmbot_os/syscalls/farmware_test.exs
+++ b/farmbot_os/test/farmbot_os/syscalls/farmware_test.exs
@@ -9,7 +9,7 @@ defmodule FarmbotOS.SysCalls.FarmwareTest do
 
     expect(FarmbotCore.LogExecutor, :execute, fn log ->
       expected =
-        "Farmware did not exit after 30.0 seconds. Terminating :FAKE_PID"
+        "Farmware did not exit after 60.0 seconds. Terminating :FAKE_PID"
 
       assert log.message == expected
       :ok


### PR DESCRIPTION
# What's New?

Change the farmware timeout from 30 seconds to 60 seconds. This is to account for the fact that some express devices will take longer than 30s to finish taking a photo.