### PR TITLE
Update scheduler_usage_reporter.ex

### DIFF
--- a/farmbot_core/lib/farmbot_core/bot_state/scheduler_usage_reporter.ex
+++ b/farmbot_core/lib/farmbot_core/bot_state/scheduler_usage_reporter.ex
@@ -77,11 +77,13 @@ defmodule FarmbotCore.BotState.SchedulerUsageReporter do
 
     _ = BotState.report_scheduler_usage(round(usage))
 
+    {:ok, load_average} = File.read("/proc/loadavg")
+
     if usage >= 99.9 do
       Logger.debug(
         "sched usage #{round(usage)}% : run queue lengths #{
           inspect(:erlang.statistics(:run_queue_lengths))
-        }"
+        } : load average #{load_average}"
       )
     end
 


### PR DESCRIPTION
When Scheduler Usage is 100% then additionally log the current Linux load average numbers.
This shows us how busy the Raspberry Pi Zero W single CPU really is.
