### PR TITLE
Usability improvement for Express

### DIFF
--- a/farmbot_core/lib/farmbot_core/firmware_side_effects.ex
+++ b/farmbot_core/lib/farmbot_core/firmware_side_effects.ex
@@ -159,6 +159,7 @@ defmodule FarmbotCore.FirmwareSideEffects do
   @impl FarmbotFirmware.SideEffects
   def handle_emergency_lock() do
     _ = FirmwareEstopTimer.start_timer()
+    _ = Leds.red(:fast_blink)
     _ = Leds.yellow(:slow_blink)
     :ok = BotState.set_firmware_locked()
   end
@@ -166,6 +167,7 @@ defmodule FarmbotCore.FirmwareSideEffects do
   @impl FarmbotFirmware.SideEffects
   def handle_emergency_unlock() do
     _ = FirmwareEstopTimer.cancel_timer()
+    _ = Leds.red(:solid)
     _ = Leds.yellow(:off)
     :ok = BotState.set_firmware_unlocked()
   end


### PR DESCRIPTION
Getting to know the Express electronics box and was surprised to notice that there's no visual cue on the lovely external RED-lit button for Emergency Stop.

This PR just provides Fast-blink RED LED visual cue on Express electronics box for E-Stop condition.
Button RED LED returns to steady solid after UNLOCK is actioned.

| caveat | This change has not been tested on any other Farmbot models.