### PR TITLE
Token related bug fix

### DIFF
--- a/farmbot_ext/coveralls.json
+++ b/farmbot_ext/coveralls.json
@@ -1,6 +1,6 @@
 {
   "coverage_options": {
     "treat_no_relevant_lines_as_covered": true,
-    "minimum_coverage": 14
+    "minimum_coverage": 16
   }
 }

--- a/farmbot_ext/lib/farmbot_ext/api.ex
+++ b/farmbot_ext/lib/farmbot_ext/api.ex
@@ -21,10 +21,8 @@ defmodule FarmbotExt.API do
   @version Project.version()
   @target Project.target()
 
-  # adapter(Tesla.Adapter.Hackney)
   plug(Tesla.Middleware.JSON, decode: &JSON.decode/1, encode: &JSON.encode/1)
   plug(Tesla.Middleware.FollowRedirects)
-  # plug(Tesla.Middleware.Logger)
 
   def client do
     binary_token = get_config_value(:string, "authorization", "token")
@@ -165,6 +163,10 @@ defmodule FarmbotExt.API do
   @doc "helper for `GET`ing a path."
   def get_body!(path) do
     case API.get(API.client(), path) do
+      {:ok, %{status: 401}} ->
+        FarmbotExt.Bootstrap.reauth()
+        {:error, "Token is expired. Please try again."}
+
       {:ok, %{body: body, status: 200}} ->
         {:ok, body}
 

--- a/farmbot_ext/lib/farmbot_ext/bootstrap.ex
+++ b/farmbot_ext/lib/farmbot_ext/bootstrap.ex
@@ -4,7 +4,6 @@ defmodule FarmbotExt.Bootstrap do
   a token, secret, or password for logging into an account
   """
 
-  # FarmbotExt.Bootstrap.Authorization.authorize_with_password(email, password, server)
   use GenServer
   require FarmbotCore.Logger
   require Logger
@@ -72,6 +71,19 @@ defmodule FarmbotExt.Bootstrap do
         Logger.error(msg)
         FarmbotCore.Logger.debug(3, msg)
         {:noreply, nil, 5000}
+    end
+  end
+
+  def reauth do
+    email = get_config_value(:string, "authorization", "email")
+    server = get_config_value(:string, "authorization", "server")
+    secret = get_config_value(:string, "authorization", "secret")
+
+    with {:ok, tkn} <- Authorization.authorize_with_secret(email, secret, server),
+         _ <- update_config_value(:string, "authorization", "token", tkn) do
+      {:ok, tkn}
+    else
+      err -> err
     end
   end
 end

--- a/farmbot_ext/lib/farmbot_ext/bootstrap.ex
+++ b/farmbot_ext/lib/farmbot_ext/bootstrap.ex
@@ -82,8 +82,6 @@ defmodule FarmbotExt.Bootstrap do
     with {:ok, tkn} <- Authorization.authorize_with_secret(email, secret, server),
          _ <- update_config_value(:string, "authorization", "token", tkn) do
       {:ok, tkn}
-    else
-      err -> err
     end
   end
 end

--- a/farmbot_ext/test/farmbot_ext/bootstrap_test.exs
+++ b/farmbot_ext/test/farmbot_ext/bootstrap_test.exs
@@ -3,16 +3,34 @@ defmodule FarmbotExt.BootstrapTest do
   use ExUnit.Case, async: false
   use Mimic
   alias FarmbotExt.Bootstrap
+  alias FarmbotExt.Bootstrap.Authorization
   setup :verify_on_exit!
-  setup :set_mimic_global
 
   test "performs a factory reset if the email is wrong" do
-    expect(FarmbotExt.Bootstrap.Authorization, :authorize_with_password, 1, fn
+    expect(Bootstrap.Authorization, :authorize_with_password, 1, fn
       _email, _password, _server ->
         {:error, "Bad email or password."}
     end)
 
     expect(FarmbotCeleryScript.SysCalls, :factory_reset, 1, fn "farmbot_os" -> :ok end)
     assert Bootstrap.try_auth("", "", "", "") == {:noreply, nil, 5000}
+  end
+
+  test "reauthorizes as needed" do
+    expect(FarmbotCore.Config, :get_config_value, 3, fn
+      :string, "authorization", "email" -> "the_email"
+      :string, "authorization", "server" -> "the_server"
+      :string, "authorization", "secret" -> "the_secret"
+    end)
+
+    expect(Authorization, :authorize_with_secret, 1, fn "the_email", "the_secret", "the_server" ->
+      {:ok, "the_token"}
+    end)
+
+    expect(FarmbotCore.Config, :update_config_value, 1, fn
+      :string, "authorization", "token", "the_token" -> :ok
+    end)
+
+    {:ok, "the_token"} = Bootstrap.reauth()
   end
 end

--- a/farmbot_ext/test/test_helper.exs
+++ b/farmbot_ext/test/test_helper.exs
@@ -9,6 +9,7 @@ Application.ensure_all_started(:mimic)
   FarmbotCore.Asset.Private,
   FarmbotCore.Asset.Repo,
   FarmbotCore.BotState,
+  FarmbotCore.Config,
   FarmbotCore.Leds,
   FarmbotCore.LogExecutor,
   FarmbotExt.AMQP.AutoSyncAssetHandler,
@@ -18,7 +19,7 @@ Application.ensure_all_started(:mimic)
   FarmbotExt.API.EagerLoader,
   FarmbotExt.API.EagerLoader.Supervisor,
   FarmbotExt.API.Preloader,
-  FarmbotExt.Bootstrap.Authorization
+  FarmbotExt.Bootstrap.Authorization,
 ]
 |> Enum.map(&Mimic.copy/1)
 

--- a/farmbot_ext/test/test_helper.exs
+++ b/farmbot_ext/test/test_helper.exs
@@ -19,7 +19,7 @@ Application.ensure_all_started(:mimic)
   FarmbotExt.API.EagerLoader,
   FarmbotExt.API.EagerLoader.Supervisor,
   FarmbotExt.API.Preloader,
-  FarmbotExt.Bootstrap.Authorization,
+  FarmbotExt.Bootstrap.Authorization
 ]
 |> Enum.map(&Mimic.copy/1)
 


### PR DESCRIPTION
# Problem

 * When a token expires and `sync` is called, the device goes into an endless spiral of errors

# Solution

 * Explicitly renew API tokens when API returns a 401 error.