### PR TITLE
Minor Updates

### DIFF
--- a/farmbot_core/lib/farmbot_core/asset/device.ex
+++ b/farmbot_core/lib/farmbot_core/asset/device.ex
@@ -17,8 +17,6 @@ defmodule FarmbotCore.Asset.Device do
 
     field(:name, :string)
     field(:timezone, :string)
-    field(:last_ota, :utc_datetime)
-    field(:last_ota_checkup, :utc_datetime)
     field(:ota_hour, :integer)
     field(:mounted_tool_id, :integer)
     field(:monitor, :boolean, default: true)
@@ -31,8 +29,6 @@ defmodule FarmbotCore.Asset.Device do
       id: device.id,
       name: device.name,
       timezone: device.timezone,
-      last_ota: device.last_ota,
-      last_ota_checkup: device.last_ota_checkup,
       ota_hour: device.ota_hour,
       needs_reset: device.needs_reset,
       mounted_tool_id: device.mounted_tool_id
@@ -45,8 +41,6 @@ defmodule FarmbotCore.Asset.Device do
       :id,
       :name,
       :timezone,
-      :last_ota,
-      :last_ota_checkup,
       :ota_hour,
       :mounted_tool_id,
       :monitor,

--- a/farmbot_core/test/asset/device_test.exs
+++ b/farmbot_core/test/asset/device_test.exs
@@ -6,8 +6,6 @@ defmodule FarmbotCore.Asset.DeviceTest do
     :id,
     :name,
     :timezone,
-    :last_ota,
-    :last_ota_checkup,
     :ota_hour,
     :needs_reset,
     :mounted_tool_id

--- a/farmbot_firmware/test/farmbot_firmware/command_test.exs
+++ b/farmbot_firmware/test/farmbot_firmware/command_test.exs
@@ -2,7 +2,6 @@ defmodule FarmbotFirmware.CommandTest do
   use ExUnit.Case
   use Mimic
   setup :verify_on_exit!
-  @subject FarmbotFirmware.Command
 
   def fake_pid() do
     arg = [transport: FarmbotFirmware.StubTransport, reset: StubReset]
@@ -23,10 +22,38 @@ defmodule FarmbotFirmware.CommandTest do
     assert :ok == FarmbotFirmware.command(pid, cmd)
   end
 
-  @tag :capture_log
-  test "command() refuses to run RPCs in :boot state" do
-    pid = fake_pid()
-    {:error, message} = @subject.command(pid, {:a, {:b, :c}})
-    assert "Can't send command when in :boot state" == message
+  def do_spawn_my_test(caller, code) do
+    result = FarmbotFirmware.Command.wait_for_command_result(code)
+    send(caller, result)
+  end
+
+  def spawn_my_test() do
+    # Spawn a fake GCode command.
+    # For the sake of tests, we will
+    # simulate a "parameter_read_all"
+    # command.
+    spawn(__MODULE__, :do_spawn_my_test, [
+      self(),
+      {nil, {:parameter_read_all, []}}
+    ])
+  end
+
+  test "handle {:error, message} from firmware" do
+    pid = spawn_my_test()
+    my_error = {:error, "foo bar baz"}
+    send(pid, my_error)
+    assert_receive(my_error, 500, "Expected firmware errors to be echoed")
+  end
+
+  test "handle a retry that turns in to an estop error" do
+    pid = spawn_my_test()
+    send(pid, {nil, {:report_retry, []}})
+    send(pid, {nil, {:report_emergency_lock, []}})
+
+    assert_receive(
+      {:error, :emergency_lock},
+      500,
+      "Expected firmware errors to be echoed"
+    )
   end
 end

--- a/farmbot_firmware/test/farmbot_firmware/command_test.exs
+++ b/farmbot_firmware/test/farmbot_firmware/command_test.exs
@@ -53,6 +53,35 @@ defmodule FarmbotFirmware.CommandTest do
     assert_receive(
       {:error, :emergency_lock},
       500,
+      "Expected :emergency_lock response"
+    )
+  end
+
+  test "handle report_position_change from firmware" do
+    pid = spawn_my_test()
+    send(pid, {nil, {:report_position_change, []}})
+    send(pid, {nil, {:report_error, [:no_error]}})
+    assert_receive({:ok, "ok"}, 500, "Expected OK response when :no_error")
+  end
+
+  test "handle invalid command reports from firmware" do
+    pid = spawn_my_test()
+    send(pid, {nil, {:report_invalid, []}})
+
+    assert_receive(
+      {:error, :invalid_command},
+      500,
+      "Expected firmware errors to be echoed"
+    )
+  end
+
+  test "handle invalid axis timeout from firmware" do
+    pid = spawn_my_test()
+    send(pid, {nil, {:report_axis_timeout, [:x]}})
+
+    assert_receive(
+      {:error, "axis timeout: x"},
+      500,
       "Expected firmware errors to be echoed"
     )
   end

--- a/farmbot_os/platform/target/network.ex
+++ b/farmbot_os/platform/target/network.ex
@@ -44,7 +44,12 @@ defmodule FarmbotOS.Platform.Target.Network do
         start: "192.168.24.2",
         end: "192.168.24.10"
       },
-      dnsd: %{records: [{"*", me_but_tuple}]}
+      dnsd: %{
+        records: [
+          {"setup.farm.bot", me_but_tuple},
+          {"*", me_but_tuple}
+        ]
+      }
     }
   end
 


### PR DESCRIPTION
 * Explicitly add `setup.farm.bot` to DNS records in configurator mode
 * Add more tests for firmware (looks like coverage dropped recently)
 * Remove legacy fields now that FBOS v11 is EOL