### PR TITLE
docs: fix simple typo, devicve -> device

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ Most FarmBot development/testing is done on a standard desktop PC.
   * [Provisioning OTA system](/docs/target_development/provisioning_ota_system.md)
   * [Publishing Firmware (OTAs)](/docs/target_development/releasing_target_firmware.md)
   * [Why doesn't my device boot after building firmware](docs/target_development/target_faq.md)
-  * [Inspecting a running devicve](/docs/target_development/consoles/target_console.md)
+  * [Inspecting a running device](/docs/target_development/consoles/target_console.md)
 
 ## CeleryScript
 


### PR DESCRIPTION
There is a small typo in docs/index.md

should read `device` rather than `devicve`.