### PR TITLE
Update sequence_on_boot.ex

### DIFF
--- a/lib/core/sequence_on_boot.ex
+++ b/lib/core/sequence_on_boot.ex
@@ -1,9 +1,38 @@
 defmodule FarmbotOS.SequenceOnBoot do
   @moduledoc """
-  Send an existing Sequence to be scheduled for execution.
+  Request an existing Sequence to be scheduled for execution at earliest opportunity.
+
+  Process code which can be run by a "fire-and-forget" Supervised Task.
   """
 
   def schedule_boot_sequence() do
+    with "synced" <-
+           FarmbotOS.BotState.subscribe().informational_settings.sync_status do
+      do_schedule_sequence()
+    else
+      _not_yet ->
+        await_fbos_synced()
+    end
+  end
+
+  defp await_fbos_synced() do
+    receive do
+      {FarmbotOS.BotState,
+       %{
+         changes: %{
+           informational_settings: %{changes: %{sync_status: sync_status}}
+         }
+       }} ->
+        with "synced" <- sync_status do
+          do_schedule_sequence()
+        else
+          _not_yet ->
+            await_fbos_synced()
+        end
+    end
+  end
+
+  defp do_schedule_sequence do
     boot_sequence_id = FarmbotOS.Asset.fbos_config(:boot_sequence_id)
 
     if not is_nil(boot_sequence_id) do


### PR DESCRIPTION
Fix for PR#1487 for Issue#792 where Boot Sequence may fail to be scheduled right after the initial FBOS boot after a **`Soft`** ( Factory ) **`Reset`**.