### PR TITLE
Avoid unnecessary spawns spamming the Red LED

### DIFF
--- a/lib/firmware/inbound_side_effects.ex
+++ b/lib/firmware/inbound_side_effects.ex
@@ -17,7 +17,14 @@ defmodule FarmbotOS.Firmware.InboundSideEffects do
   def process(state, gcode_list) do
     # Spawn() so that LED problems don't cause FW Handler to
     # hang or crash
-    unless UARTCoreSupport.locked?(), do: spawn(Leds, :red, [:solid])
+    red_led_pid =
+      unless UARTCoreSupport.locked?() do
+        unless is_pid(state.red_led_pid) do
+          spawn(Leds, :red, [:solid])
+        else
+          state.red_led_pid
+        end
+      end
 
     if state.logs_enabled do
       reject = [
@@ -37,7 +44,7 @@ defmodule FarmbotOS.Firmware.InboundSideEffects do
     end
 
     state = Enum.reduce(gcode_list, state, &reduce/2)
-    %{state | rx_count: state.rx_count + 1}
+    %{state | rx_count: state.rx_count + 1, red_led_pid: red_led_pid}
   end
 
   defp reduce({:debug_message, string}, state) do
@@ -193,8 +200,7 @@ defmodule FarmbotOS.Firmware.InboundSideEffects do
     do: maxed(s, :z, v)
 
   defp reduce(
-         {:report_updated_param_during_calibration,
-          %{pin_or_param: p, value1: v}},
+         {:report_updated_param_during_calibration, %{pin_or_param: p, value1: v}},
          state
        ) do
     k = FarmbotOS.Firmware.Parameter.translate(trunc(p))

--- a/lib/firmware/uart_core.ex
+++ b/lib/firmware/uart_core.ex
@@ -35,7 +35,8 @@ defmodule FarmbotOS.Firmware.UARTCore do
             rx_count: 0,
             rx_buffer: RxBuffer.new(),
             tx_buffer: TxBuffer.new(),
-            pin_watcher: nil
+            pin_watcher: nil,
+            red_led_pid: nil
 
   # The Firmware has a 120 second default timeout.
   # Queuing up 10 messages that take one minute each == 10 minutes.


### PR DESCRIPTION
Noticed that the Erlang PID numbers were changing very rapidly and found that _**every**_ incoming packet of GCODEs from the Firmware was initiating a **`spawn (Leds, :red, [:solid])`** . . that's about 10..12 **per second** !

This change reduces the Erlang **process** churning and the load on `Circuits.GPIO` etc (, therefore the CPU effort // Scheduler usage ) by a noticeable amount.
( beneficial for the Express V1.0 systems )
