### PR TITLE
Update execute_compiler.ex

### DIFF
--- a/lib/celery/compilers/execute_compiler.ex
+++ b/lib/celery/compilers/execute_compiler.ex
@@ -19,7 +19,7 @@ defmodule FarmbotOS.Celery.Compiler.Execute do
       %AST{kind: :sequence} = sequence_ast ->
         quote location: :keep do
           # execute_compiler.ex
-          sequence = unquote(sequence_ast)
+          sequence = unquote(Macro.escape(sequence_ast))
           cs_scope = unquote(Scope.new(previous_scope, execute_ast.body))
           FarmbotOS.Celery.Compiler.Sequence.sequence(sequence, cs_scope)
         end


### PR DESCRIPTION
Elixir Compiler was unable to warn about `sequence_ast` being a Map/Struct because it had no knowledge of whether it was "`quote-d`" or not.

Relates to FarmBot Forum thread https://forum.farmbot.org/t/my-sequence-will-not-be-executed/8190