### PR TITLE
Fix map_to_table/1 crash on nested lists

### DIFF
--- a/lib/os/lua/util.ex
+++ b/lib/os/lua/util.ex
@@ -4,6 +4,7 @@ defmodule FarmbotOS.Lua.Util do
     Enum.map(map, fn
       {key, %DateTime{} = dt} -> {to_string(key), to_string(dt)}
       {key, %{} = value} -> {to_string(key), map_to_table(value)}
+      {key, value} when is_list(value) -> {to_string(key), map_to_table(value)}
       {key, value} -> {to_string(key), value}
     end)
   end
@@ -11,7 +12,7 @@ defmodule FarmbotOS.Lua.Util do
   def map_to_table(list) when is_list(list) do
     list
     |> Enum.with_index()
-    |> Enum.map(fn {val, inx} -> {inx + 1, val} end)
+    |> Enum.map(fn {val, inx} -> {inx + 1, map_to_table(val)} end)
     |> Map.new()
   end
 

--- a/lib/os/lua/util.ex
+++ b/lib/os/lua/util.ex
@@ -12,7 +12,10 @@ defmodule FarmbotOS.Lua.Util do
   def map_to_table(list) when is_list(list) do
     list
     |> Enum.with_index()
-    |> Enum.map(fn {val, inx} -> {inx + 1, map_to_table(val)} end)
+    |> Enum.map(fn
+      {%DateTime{} = dt, inx} -> {inx + 1, to_string(dt)}
+      {val, inx} -> {inx + 1, map_to_table(val)}
+    end)
     |> Map.new()
   end
 

--- a/test/os/lua/util_test.exs
+++ b/test/os/lua/util_test.exs
@@ -11,6 +11,18 @@ defmodule FarmbotOS.Lua.UtilTest do
     assert expected == actual
   end
 
+  test "map_to_table/1 converts a list-valued entry instead of passing it through raw" do
+    expected = [{"nums", %{1 => 1, 2 => 2, 3 => 3}}]
+    actual = Util.map_to_table(%{nums: [1, 2, 3]})
+    assert expected == actual
+  end
+
+  test "map_to_table/1 recurses into maps nested inside a list" do
+    expected = %{1 => [{"a", 1}], 2 => [{"b", 2}]}
+    actual = Util.map_to_table([%{a: 1}, %{b: 2}])
+    assert expected == actual
+  end
+
   test "table_to_map" do
     table = [
       {"array",

--- a/test/os/lua/util_test.exs
+++ b/test/os/lua/util_test.exs
@@ -11,7 +11,7 @@ defmodule FarmbotOS.Lua.UtilTest do
     assert expected == actual
   end
 
-  test "map_to_table/1 converts a list-valued entry instead of passing it through raw" do
+  test "map_to_table/1 converts a list-valued map entry" do
     expected = [{"nums", %{1 => 1, 2 => 2, 3 => 3}}]
     actual = Util.map_to_table(%{nums: [1, 2, 3]})
     assert expected == actual

--- a/test/os/lua/util_test.exs
+++ b/test/os/lua/util_test.exs
@@ -29,6 +29,13 @@ defmodule FarmbotOS.Lua.UtilTest do
     assert expected == actual
   end
 
+  test "map_to_table/1 stringifies a DateTime inside a list" do
+    dt = ~U[2026-01-01 00:00:00Z]
+    expected = %{1 => "2026-01-01 00:00:00Z"}
+    actual = Util.map_to_table([dt])
+    assert expected == actual
+  end
+
   test "table_to_map" do
     table = [
       {"array",

--- a/test/os/lua/util_test.exs
+++ b/test/os/lua/util_test.exs
@@ -23,6 +23,12 @@ defmodule FarmbotOS.Lua.UtilTest do
     assert expected == actual
   end
 
+  test "map_to_table/1 handles an empty list value as an empty table" do
+    expected = [{"empty", %{}}]
+    actual = Util.map_to_table(%{empty: []})
+    assert expected == actual
+  end
+
   test "table_to_map" do
     table = [
       {"array",


### PR DESCRIPTION
## Summary

`read_status()` with no path argument crashes the Lua VM with `{:badkey, N}`. `map_to_table/1` recurses into nested **maps** but passes nested **lists** through raw — Luerl then cannot index the raw Elixir list. Because it is an Elixir host-level crash, a Lua `pcall` around the call does not catch it.

This:
- dispatches list-valued map entries to the existing `map_to_table/1` list clause, and
- makes that list clause recurse into its own elements, so a list of maps converts correctly too.

Fixes #1526

## Test plan

- [x] Added regression tests in `test/os/lua/util_test.exs` — a list-valued map entry, and a list of maps
- [ ] CI: `mix test test/os/lua/util_test.exs` and `mix format --check-formatted` (no local Elixir toolchain available to run these here)